### PR TITLE
feat(tools): add airy_extrinsic - extract Airy DIFOP factory extrinsic

### DIFF
--- a/FAST_LIO_SAM/tools/airy_extrinsic/.gitignore
+++ b/FAST_LIO_SAM/tools/airy_extrinsic/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/FAST_LIO_SAM/tools/airy_extrinsic/README.md
+++ b/FAST_LIO_SAM/tools/airy_extrinsic/README.md
@@ -1,0 +1,110 @@
+# airy_extrinsic — Airy DIFOP 出厂外参解析
+
+从 RoboSense Airy 的 DIFOP 包里抽取 IMU↔LiDAR **出厂标定**外参 (`qx, qy, qz, qw, x, y, z`)，自动算出 3×3 旋转矩阵 + 3×1 平移，输出可直接粘到 LIO config 的 YAML 片段。
+
+> 解决 issue #3.
+
+## 为什么需要
+
+RoboSense Airy 内置 IMU，但 IMU 的位置/朝向相对 LiDAR 是**每台单独标定的**：
+- 标定值出厂烧进固件，从 DIFOP 包字节 `1092..1119` 输出 (7 个大端 IEEE-754 float)
+- `rslidar_sdk` 解析了但**不应用**到点云/IMU 输出
+- 所以 LIO (FAST-LIO / FAST-LIO-SAM 等) **必须知道这个外参**才能正确融合 IMU
+- 不知道就只能依赖 `extrinsic_est_en: true` 在线收敛，对快速运动的机器狗来说不够稳
+
+官方 `Airy IMU外参解析.pdf` 的方法是：用 Wireshark 抓 → 找字节 → 复制粘贴到 IEEE-754 转换网站。这个工具把这一切自动化。
+
+## 安装
+
+```bash
+# 必需依赖: 仅 Python 3.8+ stdlib, 不用装别的就能跑 live / pcap
+# bag 模式可选:
+pip install rosbags
+```
+
+## 用法
+
+### 1) 在线抓包 (live)
+
+雷达接好、网卡能 ping 通时直接跑：
+
+```bash
+sudo python3 airy_extrinsic.py live --port 7788 --bind 0.0.0.0 --timeout 15
+```
+
+> `sudo` 是因为绑定 < 1024 端口要 root；7788 不需要，但有些系统对原始 UDP 也限制。
+> 如果 host 上有 rslidar_sdk 在跑，会跟它抢 7788 端口，先 stop 一下：
+> `sudo systemctl stop airy-lidar.service`
+
+### 2) Wireshark / tcpdump 抓的 pcap (pcap)
+
+```bash
+# 抓个 5 秒的 pcap (任意工具)
+sudo tcpdump -i eno1 -nn -w /tmp/airy.pcap udp port 7788 -G 5 -W 1
+
+# 离线提取
+python3 airy_extrinsic.py pcap --file /tmp/airy.pcap
+```
+
+⚠️ 必须是经典 pcap（不是 pcapng）。Wireshark 另存时选 `Wireshark/tcpdump - pcap`.
+
+### 3) 从 rosbag2 提取 (bag)
+
+前提是你录 bag 时打开了 `send_packet_ros: true`，bag 里有 `/rslidar_packets`：
+
+```bash
+python3 airy_extrinsic.py bag --bag /path/to/airy_xxx --topic /rslidar_packets
+```
+
+## 输出
+
+```yaml
+# 由 airy_extrinsic.py 自动生成 - 请勿手动编辑
+# 雷达 SN (DIFOP 字节 292..297): ABCD12345678
+# 原始四元数 [qx, qy, qz, qw] = [ 0.002710,  0.001080,  0.003860,  0.999990]
+# 四元数模长: 1.000002 (理想 = 1)
+
+mapping:
+  extrinsic_T: [ 0.012300, -0.000800,  0.042100]
+  extrinsic_R: [
+     0.999968, -0.007714,  0.002181,
+     0.007726,  0.999956, -0.005412,
+    -0.002139,  0.005428,  0.999983
+  ]
+```
+
+把 `mapping:` 块下两条直接覆盖到 `airy.yaml` 即可。
+
+## 写到文件
+
+```bash
+python3 airy_extrinsic.py live -o airy_extrinsic.yaml
+```
+
+## DIFOP 字节布局参考
+
+```
+RSAIRYDifopPkt (#pragma pack(1), 总 1248 字节):
+  offset    size  field
+  0         8     id[8]                   = A5 FF 00 5A 11 11 55 55  (DIFOP 标识)
+  ...
+  292       6     SN                      雷达序列号
+  ...
+  1092      4     qx (大端 float)
+  1096      4     qy
+  1100      4     qz
+  1104      4     qw
+  1108      4     x  (米)
+  1112      4     y
+  1116      4     z
+  ...
+  1246      2     tail
+```
+
+字段定义见 `rslidar_sdk/.../decoder_RSAIRY.hpp` 中 `RSAIRYDifopPkt`.
+
+## 自测
+
+```bash
+python3 test_airy_extrinsic.py -v
+```

--- a/FAST_LIO_SAM/tools/airy_extrinsic/airy_extrinsic.py
+++ b/FAST_LIO_SAM/tools/airy_extrinsic/airy_extrinsic.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+airy_extrinsic — 从 RoboSense Airy 的 DIFOP 包里抽取 IMU↔LiDAR 出厂外参
+
+Airy 每台出厂标定的 IMU 外参 (qx, qy, qz, qw, x, y, z) 存在 DIFOP 包字节
+偏移 1092 起 28 字节 (7 个 IEEE-754 float, 大端). rslidar_sdk 解析了但不
+应用, 用户需要把它喂到 LIO config 里, 否则只能依赖 extrinsic_est_en 在线收敛.
+
+支持三种输入:
+  1) live   : 直接从雷达网口抓 DIFOP UDP 包
+  2) pcap   : 解析 Wireshark / tcpdump 抓到的 .pcap (libpcap 格式)
+  3) bag    : 从 rosbag2 (sqlite3) 里读 /rslidar_packets 话题
+
+输出: 一段 YAML, 直接粘到 mapping_airy.yaml 的 mapping.extrinsic_T / R 即可.
+
+用法:
+  airy_extrinsic.py live  --port 7788 [--bind 0.0.0.0] [--timeout 10]
+  airy_extrinsic.py pcap  --file dump.pcap  [--port 7788]
+  airy_extrinsic.py bag   --bag <rosbag2_dir> [--topic /rslidar_packets]
+
+依赖:
+  必需: 仅 Python 3.8+ stdlib
+  bag 模式可选: pip install rosbags  (如果系统没装 ROS2 也能解 sqlite3 bag)
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import math
+import os
+import socket
+import struct
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+
+# ============================================================
+# DIFOP 字节布局常量 (Airy)
+# ============================================================
+DIFOP_LEN     = 1248
+DIFOP_ID      = bytes([0xA5, 0xFF, 0x00, 0x5A, 0x11, 0x11, 0x55, 0x55])
+EXT_OFFSET    = 1092           # qx 起始字节偏移
+EXT_BYTES     = 28             # qx,qy,qz,qw,x,y,z 共 7 个大端 float
+SN_OFFSET     = 292
+SN_BYTES      = 6
+
+
+# ============================================================
+@dataclass
+class Extrinsic:
+    qx: float
+    qy: float
+    qz: float
+    qw: float
+    tx: float
+    ty: float
+    tz: float
+    sn: str = ""
+
+    def quat_norm(self) -> float:
+        return math.sqrt(self.qx**2 + self.qy**2 + self.qz**2 + self.qw**2)
+
+    def rotation_matrix(self) -> list[list[float]]:
+        """四元数 (qx,qy,qz,qw) -> 3x3 旋转矩阵, 假设左手系正交."""
+        # 归一化, 防止数值漂移
+        n = self.quat_norm()
+        if n < 1e-9:
+            raise ValueError("退化四元数 (norm≈0), DIFOP 数据可能未填")
+        x, y, z, w = self.qx / n, self.qy / n, self.qz / n, self.qw / n
+        return [
+            [1 - 2*(y*y + z*z),     2*(x*y - z*w),     2*(x*z + y*w)],
+            [    2*(x*y + z*w), 1 - 2*(x*x + z*z),     2*(y*z - x*w)],
+            [    2*(x*z - y*w),     2*(y*z + x*w), 1 - 2*(x*x + y*y)],
+        ]
+
+
+def parse_difop(buf: bytes) -> Extrinsic:
+    """从一个 1248B DIFOP 包字节流里解外参."""
+    if len(buf) < EXT_OFFSET + EXT_BYTES:
+        raise ValueError(f"包长不足: {len(buf)} < {EXT_OFFSET + EXT_BYTES}")
+    if buf[:8] != DIFOP_ID:
+        raise ValueError(f"DIFOP id 不匹配: 期望 {DIFOP_ID.hex()}, 拿到 {buf[:8].hex()}")
+    # 大端 float
+    qx, qy, qz, qw, tx, ty, tz = struct.unpack(
+        ">7f", buf[EXT_OFFSET:EXT_OFFSET + EXT_BYTES]
+    )
+    sn_bytes = buf[SN_OFFSET:SN_OFFSET + SN_BYTES]
+    sn = sn_bytes.hex().upper()
+    return Extrinsic(qx, qy, qz, qw, tx, ty, tz, sn)
+
+
+# ============================================================
+# 输入源 1: 在线 UDP 抓包
+# ============================================================
+def collect_live(port: int, bind: str, timeout: float) -> bytes:
+    print(f"[INFO] 监听 {bind}:{port}, 等待 DIFOP (id={DIFOP_ID.hex()})")
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((bind, port))
+    sock.settimeout(timeout)
+    try:
+        deadline = (
+            None if timeout <= 0 else
+            __import__("time").monotonic() + timeout
+        )
+        while True:
+            data, _ = sock.recvfrom(4096)
+            if len(data) >= EXT_OFFSET + EXT_BYTES and data[:8] == DIFOP_ID:
+                print(f"[INFO] 抓到 DIFOP 包 ({len(data)} B)")
+                return data
+            if deadline and __import__("time").monotonic() > deadline:
+                raise TimeoutError(f"超时未收到 DIFOP 包 ({timeout}s)")
+    finally:
+        sock.close()
+
+
+# ============================================================
+# 输入源 2: pcap (libpcap 经典格式, 不支持 pcapng)
+# ============================================================
+_PCAP_MAGIC_LE = 0xA1B2C3D4   # microsecond ts, little-endian
+_PCAP_MAGIC_BE = 0xD4C3B2A1
+_PCAPNG_MAGIC  = 0x0A0D0D0A   # 提示用户用 -F libpcap
+
+
+def _iter_pcap_payloads(path: str) -> Iterator[bytes]:
+    """从 pcap 里逐包提取 UDP payload. 支持 Ethernet + IPv4 + UDP."""
+    with open(path, "rb") as f:
+        magic = struct.unpack("<I", f.read(4))[0]
+        if magic == _PCAPNG_MAGIC:
+            raise SystemExit(
+                "[ERR] 这是 pcapng 格式, 请用经典 pcap. 在 Wireshark 里"
+                "另存为 'Wireshark/tcpdump/... - pcap' 即可."
+            )
+        if magic == _PCAP_MAGIC_LE:
+            endian = "<"
+        elif magic == _PCAP_MAGIC_BE:
+            endian = ">"
+        else:
+            raise SystemExit(f"[ERR] 未识别的 pcap magic: {magic:#x}")
+        # 跳过余下文件头 (24 字节总长)
+        f.read(20)
+        rec_hdr = struct.Struct(endian + "IIII")  # ts_sec, ts_usec, incl_len, orig_len
+        while True:
+            hdr = f.read(rec_hdr.size)
+            if len(hdr) < rec_hdr.size:
+                return
+            _, _, incl_len, _ = rec_hdr.unpack(hdr)
+            data = f.read(incl_len)
+            if len(data) < 14:
+                continue
+            # Ethernet
+            ethertype = struct.unpack(">H", data[12:14])[0]
+            if ethertype == 0x8100:  # 802.1Q VLAN
+                ethertype = struct.unpack(">H", data[16:18])[0]
+                ip_off = 18
+            else:
+                ip_off = 14
+            if ethertype != 0x0800:  # IPv4
+                continue
+            if len(data) < ip_off + 20:
+                continue
+            ihl = (data[ip_off] & 0x0F) * 4
+            proto = data[ip_off + 9]
+            if proto != 17:  # UDP
+                continue
+            udp_off = ip_off + ihl
+            if len(data) < udp_off + 8:
+                continue
+            payload = data[udp_off + 8:]
+            yield payload
+
+
+def collect_pcap(path: str, port_filter: int | None) -> bytes:
+    print(f"[INFO] 解析 pcap: {path}")
+    for payload in _iter_pcap_payloads(path):
+        # 端口过滤已隐含在 UDP payload 长度里; 我们直接看 DIFOP id
+        if len(payload) >= EXT_OFFSET + EXT_BYTES and payload[:8] == DIFOP_ID:
+            return payload
+    raise SystemExit("[ERR] pcap 里没找到任何 Airy DIFOP 包")
+
+
+# ============================================================
+# 输入源 3: rosbag2 (sqlite3) - 用 rosbags 库做最少依赖解码
+# ============================================================
+def collect_bag(bag_path: str, topic: str) -> bytes:
+    try:
+        from rosbags.rosbag2 import Reader
+        from rosbags.typesys import Stores, get_typestore
+    except ImportError as e:
+        raise SystemExit(
+            "[ERR] 需要 rosbags 库: pip install rosbags"
+        ) from e
+
+    typestore = get_typestore(Stores.ROS2_HUMBLE)
+    print(f"[INFO] 读取 rosbag2: {bag_path}, 话题: {topic}")
+    with Reader(bag_path) as reader:
+        # 找话题
+        connections = [c for c in reader.connections if c.topic == topic]
+        if not connections:
+            avail = ", ".join(c.topic for c in reader.connections)
+            raise SystemExit(
+                f"[ERR] bag 内没有 {topic} 话题. 已有: {avail}\n"
+                f"      请录制时加上 /rslidar_packets, 或用 live/pcap 模式."
+            )
+        for conn, _, raw in reader.messages(connections=connections):
+            msg = typestore.deserialize_cdr(raw, conn.msgtype)
+            # rslidar_msgs/msg/RslidarPacket 的 data 字段是 1248B
+            data = bytes(msg.data) if hasattr(msg, "data") else bytes(msg.bytes)
+            if len(data) >= EXT_OFFSET + EXT_BYTES and data[:8] == DIFOP_ID:
+                return data
+    raise SystemExit(
+        f"[ERR] bag 内 {topic} 没有任何 DIFOP 包. 录制时是否启用 send_packet_ros?"
+    )
+
+
+# ============================================================
+# YAML 输出
+# ============================================================
+def render_yaml(ext: Extrinsic) -> str:
+    R = ext.rotation_matrix()
+    norm = ext.quat_norm()
+    sn_pretty = ext.sn if ext.sn else "(unknown)"
+    return (
+        "# 由 airy_extrinsic.py 自动生成 - 请勿手动编辑\n"
+        f"# 雷达 SN (DIFOP 字节 292..297): {sn_pretty}\n"
+        f"# 原始四元数 [qx, qy, qz, qw] = "
+        f"[{ext.qx: .6f}, {ext.qy: .6f}, {ext.qz: .6f}, {ext.qw: .6f}]\n"
+        f"# 四元数模长: {norm:.6f} (理想 = 1)\n"
+        "\n"
+        "mapping:\n"
+        f"  extrinsic_T: [{ext.tx: .6f}, {ext.ty: .6f}, {ext.tz: .6f}]\n"
+        "  extrinsic_R: [\n"
+        f"    {R[0][0]: .6f}, {R[0][1]: .6f}, {R[0][2]: .6f},\n"
+        f"    {R[1][0]: .6f}, {R[1][1]: .6f}, {R[1][2]: .6f},\n"
+        f"    {R[2][0]: .6f}, {R[2][1]: .6f}, {R[2][2]: .6f}\n"
+        "  ]\n"
+    )
+
+
+# ============================================================
+# CLI
+# ============================================================
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = p.add_subparsers(dest="mode", required=True)
+
+    p_live = sub.add_parser("live", help="实时抓 UDP DIFOP 包")
+    p_live.add_argument("--port", type=int, default=7788, help="DIFOP 端口 (默认 7788)")
+    p_live.add_argument("--bind", default="0.0.0.0", help="绑定网卡 IP (默认 0.0.0.0)")
+    p_live.add_argument("--timeout", type=float, default=15.0, help="超时秒 (默认 15)")
+
+    p_pcap = sub.add_parser("pcap", help="离线解析 pcap")
+    p_pcap.add_argument("--file", required=True, help="pcap 路径")
+    p_pcap.add_argument("--port", type=int, default=None, help="(可选) 端口过滤, 默认按 DIFOP id 匹配")
+
+    p_bag = sub.add_parser("bag", help="从 rosbag2 (sqlite3) 提取")
+    p_bag.add_argument("--bag", required=True, help="rosbag2 目录")
+    p_bag.add_argument("--topic", default="/rslidar_packets", help="话题名 (默认 /rslidar_packets)")
+
+    p.add_argument("-o", "--output", help="输出 YAML 文件 (默认打印到 stdout)")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.mode == "live":
+        buf = collect_live(args.port, args.bind, args.timeout)
+    elif args.mode == "pcap":
+        buf = collect_pcap(args.file, args.port)
+    elif args.mode == "bag":
+        buf = collect_bag(args.bag, args.topic)
+    else:
+        raise SystemExit("unreachable")
+
+    ext = parse_difop(buf)
+    yaml_text = render_yaml(ext)
+
+    if args.output:
+        Path(args.output).write_text(yaml_text)
+        print(f"[OK] 写出: {args.output}")
+    print(yaml_text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/FAST_LIO_SAM/tools/airy_extrinsic/test_airy_extrinsic.py
+++ b/FAST_LIO_SAM/tools/airy_extrinsic/test_airy_extrinsic.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+单元测试: 用合成 DIFOP 包验证 parse_difop 和 render_yaml 正确.
+
+跑法:
+  python3 test_airy_extrinsic.py
+"""
+import math
+import struct
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from airy_extrinsic import (
+    DIFOP_ID, DIFOP_LEN, EXT_OFFSET, EXT_BYTES,
+    SN_OFFSET, SN_BYTES,
+    parse_difop, render_yaml, Extrinsic,
+)
+
+
+def craft_difop(qx, qy, qz, qw, tx, ty, tz, sn=b'\xAB\xCD\x12\x34\x56\x78') -> bytes:
+    buf = bytearray(DIFOP_LEN)
+    buf[0:8] = DIFOP_ID
+    buf[SN_OFFSET:SN_OFFSET+SN_BYTES] = sn
+    # 大端 IEEE-754 7 个 float
+    struct.pack_into(">7f", buf, EXT_OFFSET, qx, qy, qz, qw, tx, ty, tz)
+    return bytes(buf)
+
+
+class TestParseDifop(unittest.TestCase):
+    def test_identity_quat_zero_translation(self):
+        buf = craft_difop(0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0)
+        ext = parse_difop(buf)
+        self.assertAlmostEqual(ext.qw, 1.0, places=6)
+        self.assertAlmostEqual(ext.tx, 0.0, places=6)
+        R = ext.rotation_matrix()
+        # 单位四元数 -> 单位旋转
+        for i in range(3):
+            for j in range(3):
+                self.assertAlmostEqual(R[i][j], 1.0 if i == j else 0.0, places=6)
+
+    def test_realistic_airy_extrinsic(self):
+        # 真实 Airy 量级: IMU 几乎和 LiDAR 重合, 小偏移 + 接近单位四元数
+        buf = craft_difop(
+            qx=0.00271, qy=0.00108, qz=0.00386, qw=0.99999,
+            tx=0.0123,  ty=-0.0008,  tz=0.0421,
+        )
+        ext = parse_difop(buf)
+        self.assertAlmostEqual(ext.qw, 0.99999, places=5)
+        self.assertAlmostEqual(ext.tx, 0.0123,  places=5)
+        # 模长应近似 1
+        self.assertAlmostEqual(ext.quat_norm(), 1.0, places=4)
+        # SN 取出来应能 hex
+        self.assertEqual(ext.sn, "ABCD12345678")
+
+    def test_yaw_90_rotation(self):
+        # 绕 z 轴 90°: q = (0, 0, sin45°, cos45°)
+        s = math.sin(math.pi / 4)
+        c = math.cos(math.pi / 4)
+        buf = craft_difop(0.0, 0.0, s, c, 0.1, 0.2, 0.3)
+        ext = parse_difop(buf)
+        R = ext.rotation_matrix()
+        # 期望 R = [[0,-1,0],[1,0,0],[0,0,1]]
+        self.assertAlmostEqual(R[0][0], 0.0, places=5)
+        self.assertAlmostEqual(R[0][1], -1.0, places=5)
+        self.assertAlmostEqual(R[1][0], 1.0, places=5)
+        self.assertAlmostEqual(R[1][1], 0.0, places=5)
+        self.assertAlmostEqual(R[2][2], 1.0, places=5)
+
+    def test_bad_id_raises(self):
+        buf = bytearray(DIFOP_LEN)
+        buf[0:8] = b'\x00' * 8  # 错的 id
+        with self.assertRaises(ValueError):
+            parse_difop(bytes(buf))
+
+    def test_short_packet_raises(self):
+        with self.assertRaises(ValueError):
+            parse_difop(b'\x00' * 100)
+
+    def test_zero_quat_raises(self):
+        # qw=0 也不要紧, 但 qx=qy=qz=qw=0 -> norm=0 应抛
+        ext = Extrinsic(0, 0, 0, 0, 0, 0, 0)
+        with self.assertRaises(ValueError):
+            ext.rotation_matrix()
+
+
+class TestYamlOutput(unittest.TestCase):
+    def test_render_round_trip_via_eval(self):
+        buf = craft_difop(0.001, 0.002, 0.003, 0.99999, 0.01, 0.02, 0.03)
+        ext = parse_difop(buf)
+        text = render_yaml(ext)
+        self.assertIn("extrinsic_T:", text)
+        self.assertIn("extrinsic_R:", text)
+        self.assertIn("ABCD12345678", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a small Python CLI that extracts RoboSense Airy's per-unit factory-calibrated IMU↔LiDAR extrinsic from the DIFOP packet (bytes 1092..1119, 7 big-endian floats: qx, qy, qz, qw, x, y, z).
- Three input modes: `live` (UDP socket), `pcap` (tcpdump/Wireshark), `bag` (rosbag2 sqlite3).
- Output: paste-ready YAML snippet for `mapping.extrinsic_T` / `extrinsic_R`, plus SN and quaternion-norm sanity check.

## Why
- `rslidar_sdk` parses the DIFOP extrinsic into `device_info_` but never applies it. LIO algorithms need it injected manually.
- The vendor's documented workflow (Wireshark → hex dump → IEEE-754 web converter) is impractical for routine deployment, especially on a robot dog where each unit may need re-extraction after swap.
- Without the correct extrinsic, LIO has to rely on `extrinsic_est_en: true` to converge online — slow and brittle under aggressive motion.

## Test plan
- [x] 7 unit tests with synthesized DIFOP buffers (identity quat, realistic Airy-scale extrinsic, 90° rotation, malformed id, short packet, degenerate quat). All pass.
- [ ] Live capture against a real Airy unit (need user to run on the dog). Validate against the SN printed and that LIO converges faster than `extrinsic_est_en` from identity.
- [ ] PCAP from `Airy_zhtoujing.pcap` referenced in the user manual.
- [ ] rosbag2 with `/rslidar_packets` recorded (requires `send_packet_ros: true` at record time).

Closes #3