### PR TITLE
feat(lidar): native RoboSense PointXYZIRT support (closes #2)

### DIFF
--- a/FAST_LIO_SAM/config/airy.yaml
+++ b/FAST_LIO_SAM/config/airy.yaml
@@ -1,0 +1,102 @@
+# RoboSense Airy 192/96 线 - 原生 PointXYZIRT 路径 (lidar_type=5).
+# 直接订阅 rslidar_sdk 的 /rslidar_points + /rslidar_imu_data,
+# 不再需要 airy_bridge.
+#
+# 前提: rslidar_sdk 编译时 POINT_TYPE=XYZIRT + ENABLE_IMU_DATA_PARSE=ON.
+#
+# 用法:
+#   ros2 launch fast_lio_sam mapping_airy.launch.py
+/**:
+  ros__parameters:
+    publish:
+      path_en: true
+      scan_publish_en: true
+      dense_publish_en: true
+      scan_bodyframe_pub_en: false
+
+    common:
+      lid_topic: "/rslidar_points"     # 原生订阅, 无需 bridge
+      imu_topic: "/rslidar_imu_data"
+      time_sync_en: false
+      data_mode: 0
+      bag_path: ""
+      gnss_topic: "/gps/fix"
+
+    preprocess:
+      blind: 0.5
+      lidar_type: 5                    # RSLIDAR_NEW (PointXYZIRT, double timestamp)
+      scan_line: 96                    # Airy 96-channel 模式; 192 模式时改 192
+      scan_rate: 10
+      livox_type: 1                    # 不用, 占位
+
+    mapping:
+      acc_cov: 0.1
+      gyr_cov: 0.1
+      b_acc_cov: 0.0001
+      b_gyr_cov: 0.0001
+      fov_degree: 360.0
+      det_range: 60.0
+      extrinsic_est_en: true            # 外参在线估计 (无 DIFOP 真值时)
+      extrinsic_T: [0.0, 0.0, 0.0]
+      extrinsic_R: [1.0, 0.0, 0.0,
+                    0.0, 1.0, 0.0,
+                    0.0, 0.0, 1.0]
+      extrinT_Gnss2Lidar: [0.0, 0.0, 0.0]
+      extrinR_Gnss2Lidar: [1.0, 0.0, 0.0,
+                           0.0, 1.0, 0.0,
+                           0.0, 0.0, 1.0]
+
+    pcd_save:
+      pcd_save_en: true
+      interval: -1
+
+    feature_extract_enable: false
+    point_filter_num: 4               # Airy 单帧 ~86k 点, 取 1/4 减算力
+    max_iteration: 4
+    filter_size_corner: 0.3
+    filter_size_surf: 0.3
+    filter_size_map: 0.3
+    cube_side_length: 1000.0
+    runtime_pos_log_enable: false
+    map_file_path: ""
+
+    odometrySurfLeafSize: 0.2
+    mappingCornerLeafSize: 0.1
+    mappingSurfLeafSize: 0.2
+    z_tollerance: 1000.0
+    rotation_tollerance: 1000.0
+
+    numberOfCores: 4
+    mappingProcessInterval: 0.15
+
+    # 关键帧 (SAM)
+    surroundingkeyframeAddingDistThreshold: 1.0
+    surroundingkeyframeAddingAngleThreshold: 0.2
+    surroundingKeyframeDensity: 2.0
+    surroundingKeyframeSearchRadius: 50.0
+
+    # 回环检测 (SAM/PGO)
+    loopClosureEnableFlag: true
+    loopClosureFrequency: 1.0
+    surroundingKeyframeSize: 50
+    historyKeyframeSearchRadius: 15.0
+    historyKeyframeSearchTimeDiff: 30.0
+    historyKeyframeSearchNum: 25
+    historyKeyframeFitnessScore: 0.3
+
+    # GPS
+    useImuHeadingInitialization: false
+    useGpsElevation: false
+    gpsCovThreshold: 2.0
+    poseCovThreshold: 25.0
+
+    # 可视化
+    globalMapVisualizationSearchRadius: 1000.0
+    globalMapVisualizationPoseDensity: 10.0
+    globalMapVisualizationLeafSize: 1.0
+
+    visulize_IkdtreeMap: false
+    recontructKdTree: true
+
+    savePCD: true
+    savePCDDirectory: "/Downloads/LOAM/"

--- a/FAST_LIO_SAM/launch/mapping_airy.launch.py
+++ b/FAST_LIO_SAM/launch/mapping_airy.launch.py
@@ -1,0 +1,73 @@
+"""
+fast-lio-sam 实时建图 launch (RoboSense Airy, 原生 PointXYZIRT 路径).
+配合 rslidar_sdk 的 POINT_TYPE=XYZIRT + ENABLE_IMU_DATA_PARSE=ON 编译,
+直接订阅 /rslidar_points + /rslidar_imu_data, 不需要 airy_bridge 中转.
+
+  # 实时:
+  ros2 launch fast_lio_sam mapping_airy.launch.py
+
+  # bag 回放 (use mapping_bag.launch.py instead):
+  ros2 launch fast_lio_sam mapping_bag.launch.py \\
+       bag:=<path> config_file:=<...>/airy.yaml
+"""
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    pkg_share = get_package_share_directory('fast_lio_sam')
+    default_cfg = os.path.join(pkg_share, 'config', 'airy.yaml')
+    default_rviz = os.path.join(pkg_share, 'rviz_cfg', 'fastlio_hk.rviz')
+
+    arg_use_sim_time = DeclareLaunchArgument(
+        'use_sim_time', default_value='false',
+        description='LIVE 建图设 false; bag 回放设 true (但建议直接用 mapping_bag.launch.py)'
+    )
+    arg_config = DeclareLaunchArgument(
+        'config_file', default_value=default_cfg,
+        description='YAML 配置 (默认 airy.yaml)'
+    )
+    arg_rviz = DeclareLaunchArgument(
+        'rviz', default_value='true',
+        description='是否启动 RViz'
+    )
+    arg_rviz_cfg = DeclareLaunchArgument(
+        'rviz_cfg', default_value=default_rviz,
+        description='RViz 配置文件'
+    )
+
+    fastlio = Node(
+        package='fast_lio_sam',
+        executable='fastlio_mapping',
+        name='fastlio_mapping',
+        output='screen',
+        parameters=[
+            LaunchConfiguration('config_file'),
+            {'use_sim_time': LaunchConfiguration('use_sim_time')},
+        ],
+    )
+
+    rviz = Node(
+        package='rviz2',
+        executable='rviz2',
+        name='rviz2',
+        arguments=['-d', LaunchConfiguration('rviz_cfg')],
+        condition=IfCondition(LaunchConfiguration('rviz')),
+        parameters=[{'use_sim_time': LaunchConfiguration('use_sim_time')}],
+    )
+
+    return LaunchDescription([
+        arg_use_sim_time,
+        arg_config,
+        arg_rviz,
+        arg_rviz_cfg,
+        fastlio,
+        rviz,
+    ])

--- a/FAST_LIO_SAM/src/preprocess.cpp
+++ b/FAST_LIO_SAM/src/preprocess.cpp
@@ -60,6 +60,9 @@ void Preprocess::process(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &ms
         case RS128:
             rs_handler(msg);
             break;
+        case RSLIDAR_NEW:
+            rslidar_new_handler(msg);
+            break;
         case LIVOX:
             if (livox_type == LIVOX_ROS_SKYLAND) livox_ros_skyland_handler(msg);
             break;
@@ -1030,6 +1033,111 @@ void Preprocess::rs_handler(const sensor_msgs::msg::PointCloud2::ConstSharedPtr 
                     pl_surf.points.push_back(added_pt);
                 }
             }
+        }
+    }
+}
+
+// ----------------------------------------------------------------------
+// rslidar_new_handler: 现行 rslidar_sdk POINT_TYPE=XYZIRT 的 PointXYZIRT
+// (double timestamp 绝对秒) 直接喂. 不再需要 airy_bridge 中转.
+//
+// 关键差异 vs rs_handler:
+//   - 字段类型: double timestamp (绝对) vs float time (相对 ms)
+//   - timestamp 始终都有, given_offset_time 永远 true, 不需要 yaw 兜底
+//   - per-point curvature = (point.timestamp - frame_t0) * 1000  [ms]
+// ----------------------------------------------------------------------
+void Preprocess::rslidar_new_handler(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &msg) {
+    pl_surf.clear();
+    pl_corn.clear();
+    pl_full.clear();
+
+    pcl::PointCloud<robosense_ros::Point> pl_orig;
+    pcl::fromROSMsg(*msg, pl_orig);
+    int plsize = pl_orig.points.size();
+    if (plsize == 0) return;
+    pl_surf.reserve(plsize);
+
+    // 帧首时间: 找有效的最小 timestamp 当 t0
+    double t0 = 0.0;
+    bool t0_set = false;
+    for (int i = 0; i < plsize; ++i) {
+        const double t = pl_orig.points[i].timestamp;
+        if (std::isfinite(t) && (!t0_set || t < t0)) {
+            t0 = t;
+            t0_set = true;
+        }
+    }
+    if (!t0_set) {
+        // 整帧 timestamp 都是 NaN, 退化用 header.stamp
+        t0 = rclcpp::Time(msg->header.stamp).seconds();
+    }
+
+    given_offset_time = true;  // 我们始终能算出 per-point time, 不需 yaw 兜底
+
+    if (feature_enabled) {
+        // 特征提取路径: 按 ring 分桶
+        const int n_scan = std::min(N_SCANS, kMaxScanLines);
+        for (int i = 0; i < n_scan; ++i) {
+            pl_buff[i].clear();
+            pl_buff[i].reserve(plsize / std::max(n_scan, 1));
+        }
+        for (int i = 0; i < plsize; ++i) {
+            const auto &p = pl_orig.points[i];
+            if (p.ring >= n_scan) continue;
+            if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) continue;
+            PointType added_pt;
+            added_pt.normal_x = 0;
+            added_pt.normal_y = 0;
+            added_pt.normal_z = 0;
+            added_pt.x = p.x;
+            added_pt.y = p.y;
+            added_pt.z = p.z;
+            added_pt.intensity = p.intensity;
+            added_pt.curvature = std::isfinite(p.timestamp)
+                                     ? static_cast<float>((p.timestamp - t0) * 1000.0)
+                                     : 0.0f;  // ms
+            pl_buff[p.ring].points.push_back(added_pt);
+        }
+        for (int j = 0; j < n_scan; ++j) {
+            PointCloudXYZI &pl = pl_buff[j];
+            int linesize = pl.size();
+            if (linesize < 2) continue;
+            std::vector<orgtype> &types = typess[j];
+            types.clear();
+            types.resize(linesize);
+            linesize--;
+            for (uint i = 0; i < (uint)linesize; ++i) {
+                types[i].range = std::sqrt(pl[i].x * pl[i].x + pl[i].y * pl[i].y);
+                vx = pl[i].x - pl[i + 1].x;
+                vy = pl[i].y - pl[i + 1].y;
+                vz = pl[i].z - pl[i + 1].z;
+                types[i].dista = vx * vx + vy * vy + vz * vz;
+            }
+            types[linesize].range =
+                std::sqrt(pl[linesize].x * pl[linesize].x + pl[linesize].y * pl[linesize].y);
+            give_feature(pl, types);
+        }
+    } else {
+        // 直接采样路径 (FAST-LIO2 推荐)
+        for (int i = 0; i < plsize; ++i) {
+            if (i % point_filter_num != 0) continue;
+            const auto &p = pl_orig.points[i];
+            if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) continue;
+            const double r2 = p.x * p.x + p.y * p.y + p.z * p.z;
+            if (r2 <= blind * blind) continue;
+
+            PointType added_pt;
+            added_pt.normal_x = 0;
+            added_pt.normal_y = 0;
+            added_pt.normal_z = 0;
+            added_pt.x = p.x;
+            added_pt.y = p.y;
+            added_pt.z = p.z;
+            added_pt.intensity = p.intensity;
+            added_pt.curvature = std::isfinite(p.timestamp)
+                                     ? static_cast<float>((p.timestamp - t0) * 1000.0)
+                                     : 0.0f;  // ms
+            pl_surf.points.push_back(added_pt);
         }
     }
 }

--- a/FAST_LIO_SAM/src/preprocess.h
+++ b/FAST_LIO_SAM/src/preprocess.h
@@ -25,7 +25,14 @@
 typedef pcl::PointXYZINormal PointType;
 typedef pcl::PointCloud<PointType> PointCloudXYZI;
 
-enum LID_TYPE { LIVOX = 1, VELO16, OUST64, RS128 };  //{1, 2, 3, 4}
+enum LID_TYPE {
+    LIVOX = 1,
+    VELO16,        // 2: Velodyne 16-line 兼容布局 (float relative time + ring)
+    OUST64,        // 3: Ouster
+    RS128,         // 4: 老 suteng_msgs 的 rslidar_ros::Point (float time, RELATIVE)
+    RSLIDAR_NEW,   // 5: 现行 rslidar_sdk v1.5+ PointXYZIRT (double timestamp, ABSOLUTE)
+                   //    覆盖 Helios / Airy / Bpearl / E1 / RS-LiDAR-M1 等
+};
 enum Feature {
     Nor,
     Poss_Plane,
@@ -115,6 +122,25 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(rslidar_ros::Point,
                                                                           curvature)(float, time, normal_x)(std::uint16_t,
                                                                                                             ring, ring))
 
+// 现行 rslidar_sdk v1.5+ 在 POINT_TYPE=XYZIRT 下输出的标准点结构.
+// 字段命名/类型/语义和老的 rslidar_ros::Point 都不一样:
+//   timestamp 是 double 绝对 UNIX 秒, ring 是 uint16.
+// 覆盖 Helios / Airy / Bpearl / E1 / M1 / Ruby Plus 等所有现行 RoboSense 雷达.
+namespace robosense_ros {
+struct EIGEN_ALIGN16 Point {
+    PCL_ADD_POINT4D;
+    PCL_ADD_INTENSITY;
+    uint16_t ring;
+    double timestamp;
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+}  // namespace robosense_ros
+POINT_CLOUD_REGISTER_POINT_STRUCT(robosense_ros::Point,
+                                  (float, x, x)(float, y, y)(float, z, z)
+                                  (float, intensity, intensity)
+                                  (std::uint16_t, ring, ring)
+                                  (double, timestamp, timestamp))
+
 namespace ouster_ros {
 struct EIGEN_ALIGN16 Point {
     PCL_ADD_POINT4D;
@@ -175,8 +201,11 @@ class Preprocess {
 
     // ---- 数据成员 ----
     PointCloudXYZI pl_full, pl_corn, pl_surf;       // 全部点 / 角点 / 面点
-    PointCloudXYZI pl_buff[128];                    // maximum 128 line lidar
-    std::vector<orgtype> typess[128];               // maximum 128 line lidar
+    // 上限 256 兼容 192 线 (Airy 是 96/192 线模式可切换).
+    // 单帧最多分线后, 192 行就够了, 256 留一点冗余.
+    static constexpr int kMaxScanLines = 256;
+    PointCloudXYZI pl_buff[kMaxScanLines];
+    std::vector<orgtype> typess[kMaxScanLines];
     int lidar_type;
     int livox_type;
     int point_filter_num;
@@ -192,6 +221,8 @@ class Preprocess {
     void velodyne_handler(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &msg);
     void livox_ros_skyland_handler(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &msg);
     void rs_handler(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &msg);
+    // 现行 rslidar_sdk PointXYZIRT (double timestamp) 路径, 见 LID_TYPE::RSLIDAR_NEW
+    void rslidar_new_handler(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &msg);
     void give_feature(PointCloudXYZI &pl, std::vector<orgtype> &types);
     int plane_judge(const PointCloudXYZI &pl, std::vector<orgtype> &types, uint i, uint &i_nex,
                     Eigen::Vector3d &curr_direct);


### PR DESCRIPTION
## Summary
Adds a new `lidar_type=5` (`RSLIDAR_NEW`) that consumes current `rslidar_sdk v1.5+` `PointXYZIRT(double timestamp)` format directly. **Eliminates the airy_bridge intermediate node** when feeding RoboSense lidars (Helios / Airy / Bpearl / E1 / M1 / Ruby Plus).

## What changed

- `preprocess.h`:
  - new `robosense_ros::Point` struct matching `rslidar_sdk` exactly (`x/y/z/intensity` + `uint16_t ring` + `double timestamp`)
  - `LID_TYPE::RSLIDAR_NEW = 5` enum entry
  - `pl_buff[]` and `typess[]` bumped from 128 to 256 (`kMaxScanLines`) so 192-line modes don't silently overflow
  - declaration of `rslidar_new_handler`
- `preprocess.cpp`:
  - `process()` dispatches `lidar_type==5` to the new handler
  - new `rslidar_new_handler()`:
    - `frame_t0 = min finite timestamp in the frame` (skipping NaN)
    - `added_pt.curvature = (p.timestamp - frame_t0) * 1000` [ms]
    - `given_offset_time = true` always (we have per-point time, no yaw-based fallback)
    - filters `ring >= N_SCANS`, NaN x/y/z, blind radius, point_filter_num
    - both feature_extract and direct paths
- `config/airy.yaml`: ROS2 yaml for Airy 96-channel (use `lidar_type=5`, `lid_topic=/rslidar_points`, `imu_topic=/rslidar_imu_data`)
- `launch/mapping_airy.launch.py`: LIVE-mode launch — no bridge

## Why
Previously to feed an Airy bag/stream to FAST-LIO-SAM you had to run `airy_bridge` (Python, in `dog_mapping_ws`) to convert RoboSense's `PointXYZIRT(double)` into Velodyne-compat `(float time, ring)` and pretend to be `lidar_type=2`. That cost an extra hop, an extra QoS surface, and was the source of stage-6 gotcha #4. With this PR, fastlio_mapping subscribes `/rslidar_points` natively.

## Test plan
- [x] `colcon build` clean (3min 48s on Jetson Orin)
- [x] `ros2 run fast_lio_sam fastlio_mapping --params-file airy.yaml` boots, picks up `lidar_type 5`, IMU init succeeds
- [x] LIVE on a real Airy (driver = `airy-lidar.service`, POINT_TYPE=XYZIRT) for ~120s static:
  - `/Odometry` @ 10.0 Hz
  - `/cloud_registered` @ 7.5 Hz
  - 547 MB / 17.1 M point PCD
  - 0 loop back, 0 No Effective Points
  - bbox 25 × 33 × 4 m (driver running, slight drift over 2 minutes - normal)
- [ ] Bag-replay verification (after recording a new XYZIRT bag with motion)
- [ ] 192-channel mode verification (current Airy is configured for 96-channel)

Closes #2