### PR TITLE
fix(ros2): release globals before main returns to avoid shutdown SIGSEGV

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,6 @@ python3 .../tools/airy_extrinsic/airy_extrinsic.py live --port 7788 -o airy_extr
 
 ## 已知小毛病 / TODO
 
-- **shutdown segfault**: ROS2 port 退出时偶尔 `terminate called after throwing an instance of 'std::system_error'`。PCD 已落盘后才发生, 不丢数据, 但需要 fix。怀疑 spin 循环里 `rclcpp::shutdown()` 后还有 publisher/subscriber 析构。
 - **`wrapper/bag_io.cc` 禁用中**: 依赖内部 `lightning` framework (IMUPtr / Vec3d / global ToSec), 不在 repo 里。`#include` 注释了, CMakeLists 不编。离线回放走 `ros2 bag play --clock` 路径 (`mapping_bag.launch.py`)。
 - **PGO 静止欠定**: SAM 因子图在纯静止数据上会抛 `IndeterminantLinearSystemException`。算法本性, 不是 bug, 但要在文档里 highlight。
 - **`scan_line` 与硬件**: Airy 96/192 模式可切, 但 yaml 里要手动改 (rslidar_sdk DIFOP install_mode 决定实际值)。当前 `airy.yaml` 写 96。

--- a/FAST_LIO_SAM/src/laserMapping.cpp
+++ b/FAST_LIO_SAM/src/laserMapping.cpp
@@ -2642,5 +2642,24 @@ int main(int argc, char** argv) {
     startFlag = false;
     loopthread.join();  //  分离线程
 
+    // ROS2 移植析构顺序修复:
+    // 局部 `node` (line 2130) 在 main return 时先析构, 但下面这些全局 SharedPtr 持有
+    // node 引用; 它们在 main return 之后才析构, 此时 node context 已死,
+    // rmw 删 datawriter / service 时崩 (rmw_publish.cpp:62 / rmw_service.cpp:104, SIGSEGV).
+    // 显式按"逆创建顺序"释放, 让 node 最后死.
+    pubLoopConstraintEdge.reset();
+    pubIcpKeyFrames.reset();
+    pubHistoryKeyFrames.reset();
+    pubRecentKeyFrame.reset();
+    pubRecentKeyFrames.reset();
+    pubCloudRegisteredRaw.reset();
+    pubOptimizedGlobalMap.reset();
+    pubLaserCloudSurround.reset();
+    pubGnssPath.reset();
+    srvSavePose.reset();
+    srvSaveMap.reset();
+    g_tf_broadcaster.reset();
+
+    rclcpp::shutdown();
     return 0;
 }


### PR DESCRIPTION
## Summary
- File-scope ROS2 publishers/services/tf_broadcaster outlive the local `node` SharedPtr in `main()`, so their destructors fire after the rclcpp context is torn down → consistent SIGSEGV (exit -11) at shutdown with `cannot publish data, at rmw_publish.cpp:62` and `Fail in delete datareader, at rmw_service.cpp:104`.
- Fix: explicitly `reset()` each file-scope SharedPtr in reverse-creation order after `loopthread.join()`, then `rclcpp::shutdown()`, before `return 0`. This makes the node the last thing to die.
- Drop the matching TODO bullet from `CLAUDE.md`.

## Reproduction
Same motion bag (`airy_20260505_184528`, 124 s @ 0.5x replay rate) on two architectures:

| Platform | Before | After |
|---|---|---|
| Jetson Orin (aarch64) | `process has died exit code -11` | `process has finished cleanly` |
| Aliyun ECS (x86_64)   | `process has died exit code -11` | `process has finished cleanly` |

The `cannot publish data` / `Fail in delete datareader` rmw errors no longer appear; PCD still saves correctly.

## Test plan
- [x] Reproduce SIGSEGV on aarch64 with motion bag replay
- [x] Reproduce SIGSEGV on x86_64 (independent build) with same bag
- [x] Apply fix, rebuild, replay bag — both exit cleanly
- [x] PCD output unchanged (`current scan saved to ...`)
- [ ] LIVE-mode shutdown (Airy driver running) — not retested in this PR; logic path is identical so should benefit too

🤖 Generated with [Claude Code](https://claude.com/claude-code)