### PR TITLE
fix: airy 机器狗 bag 几公里漂飞 + loop 重影 + z 反向

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,9 @@ FAST_LIO_SAM/
 │   └── IKFoM_toolkit/   ← 流形上 IKF
 ├── config/              ← ROS2 yaml (用 `/**:\n  ros__parameters:` 包一层)
 │   ├── velodyne16.yaml
-│   ├── airy.yaml         ← Airy 原生 lidar_type=5 (狗用, 默认 ext_est=true)
+│   ├── airy_test_no_extr_est.yaml ← Airy 原生 lidar_type=5 (真实外参, **首选 — 狗用**)
 │   ├── airy_handheld.yaml ← Airy 手持采集预设 (DIFOP 真外参 + ext_est=false)
+│   ├── airy_no_loop.yaml  ← 同上但关 loop closure
 │   └── airy_via_bridge.yaml ← Airy 走 airy_bridge 兼容路径 (lidar_type=2)
 ├── launch/
 │   ├── mapping_velodyne16.launch.py
@@ -93,13 +94,14 @@ libpcl-dev libeigen3-dev libgoogle-glog-dev libgeographic-dev
 ```bash
 ros2 launch fast_lio_sam mapping_airy.launch.py
 ```
-默认 yaml: `config/airy.yaml`, `lidar_type=5`, 订阅 `/rslidar_points` + `/rslidar_imu_data`。
+默认 yaml: `config/airy_test_no_extr_est.yaml`, `lidar_type=5`, 订阅 `/rslidar_points` + `/rslidar_imu_data`。
+**注意**: 已删除的 `airy.yaml` 用 identity 外参, 在真实 Airy 硬件 (IMU 装反) 上会让 ba 爆炸到 +2.7 m/s² → 几公里漂飞.
 
 ### bag 回放建图
 ```bash
 ros2 launch fast_lio_sam mapping_bag.launch.py \
     bag:=<rosbag2_dir> \
-    config_file:=$(ros2 pkg prefix fast_lio_sam)/share/fast_lio_sam/config/airy.yaml \
+    config_file:=$(ros2 pkg prefix fast_lio_sam)/share/fast_lio_sam/config/airy_test_no_extr_est.yaml \
     rate:=1.0 \
     stop_service:=airy-lidar.service    # ← 自动 stop driver, 完成后 start (要 NOPASSWD sudo)
 ```
@@ -154,13 +156,51 @@ python3 .../tools/airy_extrinsic/airy_extrinsic.py live --port 7788 -o airy_extr
 - launch xml → launch.py
 - yaml: 必须 `/**:\n  ros__parameters:\n` 包一层, 嵌套用 `.` (例如 `mapping.extrinsic_T`)
 
+## 2026-05-26 修复总集 (按适用范围分层)
+
+会话上下文: airy bag 跑出几公里 drift → 修外参 → loop 重影 → submap 污染 → z 反向. 全部 root cause 已 nail.
+
+### A. 通用 (任何 LiDAR + IMU 组合, 改的是 fastlio 上游的 SAM/PGO 跟 IKF 默认值)
+
+A1. **Loop closure 5 项联调** (默认配置对小室内一律出重影 — 因为 default 是大尺度 hokuyo / 室外调的):
+- `src/laserMapping.cpp` ICP setMaxCorrespondenceDistance: 150 → **5** m. 150 让 ICP 跨房间错配
+- `src/laserMapping.cpp` Loop noise 拆分: 原 `Vector6 << fitness×6` 旋转 std 高达 31°, 改 `rot=1e-6, trans=max(fitness,1e-4)`
+- `src/laserMapping.cpp` Odom edge noise: `1e-4 m² → 5e-3 m²` (1cm → 7cm std), 默认 1cm 死压 loop, 改后 PGO 才能拉
+- yaml `historyKeyframeSearchNum`: 25 → **5**. **这是最隐蔽的 bug** — submap 含 25 个邻居 KF, 跨 region 的 KF 把 drift 全污染进 target, ICP 算出 dz≈0, 实际差 45cm
+- yaml `historyKeyframeFitnessScore`: 0.3 → **0.02**. 0.3 接受 ICP RMS 55cm 烂匹配 → 错 loop 拉乱
+
+A2. **z-up convention fix** (`IMU_Processing.hpp::IMU_init`): 构造 `state.rot` 把 body-up 旋到 world +z, `state.grav = (0,0,-G_m_s2)`. 默认 fastlio 让 world frame 继承 IMU body 朝向, 装反或装歪都会让 raw 输出 (`/Odometry`, `scans.pcd`, `trajectory.pcd`) 用奇怪 z 方向, RViz/Nav2 要反复转. 数学等价但外部约定一致.
+
+A3. **删除 `airy.yaml` 这种 identity-extrinsic config**, 改默认到含真外参的 yaml. 任何 LiDAR-IMU 组合都该校外参, 不能默认 identity.
+
+### B. Airy LiDAR 特定 (这家硬件的特殊约定)
+
+B1. **IMU linear_acceleration 单位是 g (不是 ROS 标准 m/s²)**. mean_acc.norm() ≈ 1.0. FAST-LIO 内部 `acc * G/|mean_acc|` 自动 normalize 能 handle, 不用手动 fix.
+
+B2. **IMU 装反 (body z 朝下, LiDAR 朝上)**. config 必须用真实外参矩阵 (180° flip), identity 会让 ba 在 5s 内爆炸到 +2.7 m/s² → 几公里漂飞:
+```yaml
+extrinsic_T: [0.00425, 0.00418, -0.00446]
+extrinsic_R: [-0.006915, -0.999975,  0.001559,
+              -0.999950,  0.006903, -0.007273,
+               0.007262, -0.001609, -0.999972]
+```
+
+### C. Airy + 机器狗特定 (高振动平台跟 handheld 差别大)
+
+C1. **Odom edge translation noise 必须放松** (A1 列了改成 5e-3). 默认 1e-4 (1cm std) 在 handheld 都已偏紧, 在狗这种 step-impact 高振动平台直接飘. 这是 C1 跟 A1 重合的部分 — 哪怕只跑 handheld 也该改, 但跑狗这种平台**绝对必须**改.
+
+C2. **后续可能要调 IMU cov** (`mapping.acc_cov`/`gyr_cov`): 默认 0.1, 狗高动态时 (gyro 1-2 rad/s, acc ±4g shock) 可能要 0.3-0.5. 当前 bag 还算温和, 没踩到. 跑跑跳跳的 bag 上 drift 还顶不住时再调.
+
+C3. **狗有大量"停一会儿转一圈"行为**, 一个 bag 里多次原地旋转扫描. 这种采集 mode 让 `historyKeyframeSearchNum` 默认 25 的 submap 跨多个停留点 (各 z 略不同), 污染特别严重. 改 5 是这个采集模式的必需 (handheld 一次性扫一个房间问题不大).
+
 ## 已知小毛病 / TODO
 
+- **shutdown segfault**: ROS2 port 退出时偶尔 `terminate called after throwing an instance of 'std::system_error'`。PCD 已落盘后才发生, 不丢数据, 但需要 fix。怀疑 spin 循环里 `rclcpp::shutdown()` 后还有 publisher/subscriber 析构。
 - **`wrapper/bag_io.cc` 禁用中**: 依赖内部 `lightning` framework (IMUPtr / Vec3d / global ToSec), 不在 repo 里。`#include` 注释了, CMakeLists 不编。离线回放走 `ros2 bag play --clock` 路径 (`mapping_bag.launch.py`)。
 - **PGO 静止欠定**: SAM 因子图在纯静止数据上会抛 `IndeterminantLinearSystemException`。算法本性, 不是 bug, 但要在文档里 highlight。
-- **`scan_line` 与硬件**: Airy 96/192 模式可切, 但 yaml 里要手动改 (rslidar_sdk DIFOP install_mode 决定实际值)。当前 `airy.yaml` 写 96。
+- **`scan_line` 与硬件**: Airy 96/192 模式可切, 但 yaml 里要手动改 (rslidar_sdk DIFOP install_mode 决定实际值)。当前 `airy_test_no_extr_est.yaml` 写 96。
 - **`launch` 退出时不调 `saveMap`**: `src/laserMapping.cpp` 主循环退出后没自动 call `saveMapService`, 导致 PCD 用的是前端 IEKF 状态 (可能漂飞), 不是 PGO 修正后的. 临时方案: 用 `bin/run_with_savemap.sh` 在 SIGINT 前手动 `ros2 service call /save_map`. 长期方案: 在 main 末尾或 SigHandle 后加 `if (savePCD) saveMap();` 调用 (line 2545 那行注释).
-- **gravity 没真正对齐**: FAST-LIO 在 IMU init 那 0.1s 锁死世界 z. 手持/狗站歪时整张图差几度. 用 `tools/align_floor/align_floor.py` 后处理校正.
+- **gravity 微调**: 2026-05-26 IMU init 已修正粗 z-up 朝向 (见上面 A2). 但 IMU init 那 0.1s 静态拟合还会有几度 tilt, `tools/align_floor/align_floor.py` 后处理可以再校到亚度.
 
 ## 兄弟工作区
 
@@ -182,6 +222,147 @@ python3 .../tools/airy_extrinsic/airy_extrinsic.py live --port 7788 -o airy_extr
 | #5 rosbag2 replay launch | ✅ closed (PR #10) |
 | #6 pcd_to_occgrid | ✅ closed (PR #7) |
 
+## 上机定位栈 (2026-05-11 起)
+
+**建图用 fast-lio-sam**, **上机定位用另一栈**, 两套独立:
+
+```
+/home/chenguojun/fls_ws/src/
+├── FAST_LIO_SAM/           ← 本仓库 (mapping)
+├── livox_ros_driver2/      ← Livox driver (msg-only stub)
+├── ndt_omp_ros2/           ← NDT_OMP backend (rsasaki 用; **新方案不再依赖**)
+├── lidar_localization_ros2/ ← rsasaki0109 fork (NDT 实验, **轨迹有 NDT 噪声, 已弃用**)
+└── open3d_loc/             ← deepglint/FAST_LIO_LOCALIZATION_HUMANOID humble + Airy 适配 ← ★主用
+```
+
+**当前主方案 (2026-05-12 verified, 架构 B): fast-lio-sam localization_mode**
+
+经过详细对比 (见 GitHub issues #27, #28), 选定 **scan-to-prior 单层架构**:
+- `fast-lio-sam` 启动时预加载 prior PCD 进 ikd-Tree (固定, 不再 incremental update)
+- IKF 直接 scan-to-prior 匹配, 出 `/Odometry` 直接在 prior frame
+- 不需要 open3d_loc 的 ICP correction (它跟 fastlio loc_mode 协同会双重 transform, 反而破坏)
+- 启动时 yaml `localization.init_pos_xyz/init_rot_quat` 给个粗 hint (±0.5m), 运行时 `/initialpose` (来自 relocation_node 或 RViz) 精修到 cm 级
+
+精度 (bag2-on-bag1+bag2 merged prior, vs transformed bag2 GT):
+- median NN 5-15cm (干净 prior 区域 1-3cm)
+- 95th 40cm, max 50cm
+- end-to-end loop closure 6cm
+
+冷启动 cm 级流程:
+```bash
+ros2 launch open3d_loc airy_fastlio_loc_cold_start.launch.py rate:=1.0
+# yaml hint 偏 0.5m → fastlio 5s dm 级 → relocation_node ICP refine → /initialpose → fastlio 1s 拉到 cm 级
+```
+
+依赖: `~/open3d019` (从 isl-org/Open3D v0.19 releases prebuilt cxx11-abi tarball 解), `libc++-dev libc++abi-dev` (apt).
+
+**架构 A (备选, 弃用): fast-lio-sam mapping_mode + open3d_loc ICP correction** 已弃用. 见 issue #28: open3d_loc ICP 在跨 bag z-degeneracy 拉 7m, 修了 ICP init bug 但仍受 fastlio ikd-Tree growing 累积错几何影响 + "两个 map 打架". 架构 B 更干净更准.
+
+**bag2-on-bag1 实测**:
+| 指标 | rsasaki NDT (旧) | open3d_loc (新) |
+|---|---|---|
+| /pcl_pose density | 245 / 152s (1.6Hz) | **1301 / 132s (10Hz)** |
+| Median 速度 | 3.3 m/s (噪声主导) | **0.94 m/s (真实步行)** |
+| z std | 2.29m | **1.16m** |
+| 轨迹形态 | xy 乱跳 | 平滑跟 corridor |
+
+**rsasaki 路线弃用原因**: NDT_OMP 在 bag1 prior + bag2 scan 上 fitness median 0.6 但对应 RMS ~0.8m, 帧间跳 1-2m. Open3D ICP 同数据 fitness 0.6-0.9 / rmse 0.27m, 是质的差距. 弃用. 留 lidar_localization_ros2 包当 fallback / 参考.
+
+**关键 3 件套 (rsasaki 时代用过, open3d_loc 不需要了)**:
+- `lidar_localization_ros2` (上游): NDT_OMP scan-to-map 跟踪, 接受 `/initialpose` (RViz click 或程式发) — 已弃用
+- `scripts/auto_init_pose.py`: 启动时用 ScanContext++ (`pyscancontext` pip 装) 把 bag1 226 KFs 建 DB, 头几帧自动匹配 → 发 `/initialpose` — 可复用做 init
+- `scripts/imu_reframe.py`: Airy IMU adapter (rsasaki 时代必须). **open3d_loc 不需要** (fast-lio-sam 直接吃原始 Airy IMU)
+
+**统一 launch**:
+```bash
+ros2 launch lidar_localization_ros2 airy_localization.launch.py \
+    param_yaml:=.../airy_bag2_on_bag1.yaml \
+    prior_kf_dir:=~/Downloads/LOAM_173924/pcd \
+    prior_pose_json:=~/Downloads/LOAM_173924/pose.json \
+    extrinsic_yaml:=~/results/airy_real_ext.yaml \
+    bag:=~/bags/airy_20260510_175730 rate:=2.0 bag_start_delay_sec:=8.0
+# 上机 live mode: bag:='' use_sim_time:=false
+```
+
+### 部署陷阱 (再加 4 个, 7-10):
+
+7. **base_link → rslidar 静态 TF 必须 = LiDAR-IMU 外参** (R_imu_lidar from yaml, ~180° flip), **不是 identity**. 因 fastlio mapping 时 `state.rot = I, state.pos = 0` at t=0, 保存的 prior 在 "world = IMU at t=0" frame, 跟 LiDAR 差一个 R_imu_lidar.
+
+8. **Airy IMU 三件 ROS-不标准, 必须经 `imu_reframe.py` 桥接**:
+   - **单位**: Airy 输出 `linear_acceleration` 是 **g-units** (~0.99 g), ROS 标准是 m/s² (~9.81). 节点 `auto_scale_acc=true` 自动检测 < 5 时 ×9.80665
+   - **mounting**: IMU 装反 (z 向下), LiDAR 朝上. 用 yaml extrinsic_R 的转置 = R_lidar_imu 把读数旋转到 LiDAR upright 系. 节点参数 `rotate_to_base_link=true`
+   - **acc 符号约定**: rsasaki0109 内部用 `a_world = R @ a_body + g_world` (不是 textbook 的 `- g_world`), 必须 `negate_acc=true`. 静态时 acc 才能正确归零
+   - frame_id 改成 `base_link` (避开 TF 二次旋转)
+
+9. **`/initialpose` 类型必须 `PoseWithCovarianceStamped`** — 不是 PoseStamped. RViz "2D Pose Estimate" 默认就发这个. CLI 测试时用 `ros2 topic pub --once /initialpose geometry_msgs/msg/PoseWithCovarianceStamped ...`.
+
+10. **`set_initial_pose: true` 模式下 yaml 的 init_pose 只用一次, 运行时 /initialpose 被忽略**. 想自动重定位必须 `set_initial_pose: false`, 让 auto_init_pose 在 SC 匹配后再发 /initialpose.
+
+11. **跨 bag GT init 必须用 scan-vs-prior ICP 推, 不能用 Procrustes-via-trajectory-files** (bag2-on-bag1 最大坑):
+   - **教训**: 上次 session 用 Procrustes(bag1 `trajectory.pcd` ↔ bag2 `trajectory_in_bag1RAW.pcd`)
+     算 bag2 t=0 init pose. mean residual 0 看着完美, 实际**错了 5m** (z 错 4.33m, yaw 错 20°).
+     根因: 输入的 `trajectory_in_bag1RAW.pcd` 本身是用错的整体 ICP 算出来的, 错传进 Procrustes.
+   - **正解**: 用 `scripts/derive_init_via_scan_icp.py`: 拿 bag2 第一帧 LiDAR scan, 跟 bag1 prior PCD 直接
+     Open3D multi-scale ICP. 要求 fitness >0.9, inlier_rmse <0.5m 才算 OK. 输出 T_map_baselink
+     的 (x,y,z, qx,qy,qz,qw) 粘进 yaml.
+   - **症状**: init 错时 NDT 一直在拼命修正, 把 pose 拉到真实 z. 之前误判成 "NDT z-degeneracy / 6DoF
+     局部最小", 加 z-filter prior / use_imu=false / threshold 调大 / local_map_crop 都治标. **根因就是 init 错**.
+   - 一旦 init 对了 (scan-vs-prior ICP fitness 0.975 / inlier_rmse 0.36m), 上面那些复杂调参不需要,
+     full prior + NDT + IMU 都能稳跟.
+
+12. **跨 bag NDT IMU 副作用 (在 init 已对的前提下还要小心)**:
+   - `use_imu: true` 跨 bag 可能让 deskew 把扫描扭歪 (Airy 外参未精校 ~5cm/帧). 同 bag 完美, 跨 bag 谨慎.
+   - `imu_prediction_correction_guard_yaw_deg` 默认 4°, 跨 bag IMU 30s 累积漂 25° → 一次 NDT 大修正
+     就把 IMU preintegration 永久禁掉. 想保留 IMU 放宽到 30°. 根因还是外参未精校.
+   - `enable_local_map_crop: true`, `local_map_radius: 30.0` 跨 bag 强烈建议开. 不开 3.7M 点全图 NDT
+     单帧 >10s, executor 卡死 IMU 灌不进来.
+
+14. **vs-GT eval 揭穿了"看起来对"的定位** (2026-05-12 末发现, 未解决):
+   - 合并 prior 跑通后 (fitness 0.994, z=-1m 真实地板, 86% 覆盖), 我以为定位就 OK 了.
+     但用 bag2 self-trajectory.pcd 当 GT 做对比, **median 3D 误差 8m**, 95th 17m.
+   - 形态: ICP 校正一次 → pose 拉回 1-2m → fast-lio 漂 2.5s → 又错 5-15m → ICP 再拉回. 反复.
+   - 用户一句话点醒: "2.5s 飘 5m, 这是 odometry 问题". fast-lio 正常应该 cm/min 漂,
+     2 m/s 漂移率 = 完全坏掉. 提高 ICP 频率治标不治本.
+   - **下次接手要查的根因方向**: (1) fastlio_airy_for_loc.yaml extrinsic/IMU cov 是否准, (2) bag2
+     mapping 当时 yaml 跟现在用的一不一样, (3) use_sim_time 是否传到 fastlio_mapping, (4)
+     scan_bodyframe_pub_en:true 是否触发 fastlio 副作用, (5) 单独跑 fastlio 不接 open3d_loc 看
+     /Odometry 是否同样漂.
+   - **见 `fls_ws/src/open3d_loc/HANDOFF.md`** 完整诊断 + 接手计划.
+
+13. **合并两次 mapping PCD 必须做 yaw sweep, 不能信任单次 ICP** (2026-05-12 大坑):
+   - bag1 + bag2 各自 fastlio-mapping 出的世界 frame 起始 yaw 任意 (取决于操作员开始扫描时的朝向),
+     两个 frame 之间可能差几十度 yaw 甚至 180° 左右.
+   - **单次 whole-map ICP 几乎必定卡 yaw 局部最优** (走廊 / 矩形大堂这种重复几何尤其严重).
+     上次 bag1↔bag2 单次 ICP 给 fitness 0.67, 看似合理, 实际是 yaw=0 stuck.
+     甚至我一度认为是反射 (`diag(-1,-1,-1)` 给 fitness 0.73), 完全错了.
+   - **正解**: ICP 之前 yaw sweep, 每 10°-30° 试一次, 取 fitness 最高的当 init, 然后 refine.
+     bag1↔bag2 yaw sweep 发现真值 yaw=+210° (相当于 -150°), 一次跑出 fitness **0.994 / rmse 0.25m**.
+   - 用户直觉很关键: 把两个 map 用不同颜色叠在 xy plot 上, 肉眼看墙体走向是否平行. 平行 = ICP 成功.
+   - 实现见 `open3d_loc/scripts/merge_bag1_bag2_priors.py` (yaw sweep + 多尺度 ICP refine).
+   - **症状**: 合并 prior 看似 OK 但 bag2 定位输出的 z 系统性 -4m 偏移 / 轨迹"穿墙". 这不是
+     NDT z-degeneracy, 是 prior 本身就被合并错了, 把 bag2 投到 bag1 frame 的错位置.
+
+### bag1-self / bag2-on-bag1 实测 (2026-05-11 ~ 12)
+| 场景 (rsasaki NDT 栈) | init pose 来源 | /pcl_pose / score-over | 评价 |
+|---|---|---|---|
+| bag1-self (no IMU) | identity (同源) | 1821 / 0 | ✅ baseline |
+| bag1-self + IMU | identity | dense / 0 | ✅ IMU 修复 verified |
+| bag2 + IMU + SC auto-init | ScanContext (yaw 错 5.76°) | sparse / 1-11 | 中等 |
+| bag2 + GT init (Procrustes 错的) + IMU + zfilt | **错的 init**, z 错 4m | 522 / 0 | ❌ 看似工作 |
+| bag2 + GT init (scan-ICP) + IMU + crop30 + full prior | scan-vs-prior ICP | 245 / 0 | ✅ 算法跑通, 但 NDT 帧间噪声 0.8m, 轨迹"zigzag" |
+
+| 场景 (open3d_loc 栈) | prior | 关键 fitness | bag2 z 中位 | 覆盖率 / 穿墙率 | 评价 |
+|---|---|---|---|---|---|
+| bag1-only prior | bag1 GlobalMap.pcd | 0.61 (live) | -5.5m | 20% / 70% | ❌ bag2 走 bag1 没看的区域 |
+| merged (单 ICP, proper-rot init) | bag1+bag2 fitness 0.67 | 0.84 (live) | -5.7m | 49% (假高) / 43% | ❌ 合并 ICP 卡 yaw 局部最优 |
+| merged (反射 seed) | bag1+bag2 fitness 0.73 | 0.89 (live) | -4.0m | 27% / 43% | ❌ 误以为是反射, 还是错 |
+| **merged (yaw sweep + proper rot)** | bag1+bag2 fitness 0.994 | 0.74 (live) | **-0.98m** ✅ | **86% / 6.9%** | ✅ **最终方案**, z 在真实地板高度 |
+
+### auto_init_pose 输出格式
+
+### auto_init_pose 输出格式
+ScanContext 匹配 bag1 KF index + delta_yaw, 节点取 `pose.json` 该 KF 的 LiDAR pose (kf.json 存的是 cloudKeyPoses6D 即 LiDAR-pose-in-world), 套上 delta_yaw Rz 修正, 再用 LiDAR-IMU 外参逆变换到 base_link pose (IMU pose), 发到 `/initialpose`. 实测 bag2 → bag1 匹配 KF 6, dist=0.06, delta_yaw=5.76°.
+
 ## 相关上游
 
 - [hku-mars/FAST_LIO `ROS2`](https://github.com/hku-mars/FAST_LIO/tree/ROS2) - 官方 FAST-LIO ROS2
@@ -189,3 +370,6 @@ python3 .../tools/airy_extrinsic/airy_extrinsic.py live --port 7788 -o airy_extr
 - [rohrschacht/FAST_LIO_SLAM_ros2](https://github.com/rohrschacht/FAST_LIO_SLAM_ros2) - SAM/PGO ROS2 移植参考
 - [TixiaoShan/LIO-SAM `ros2`](https://github.com/TixiaoShan/LIO-SAM/tree/ros2) - LIO-SAM 官方 ROS2
 - [RuanJY/robosense_fast_lio](https://github.com/RuanJY/robosense_fast_lio) - Robosense PointXYZIRT 适配参考 (PR #11 借鉴了它的 Point 结构)
+- [rsasaki0109/lidar_localization_ros2](https://github.com/rsasaki0109/lidar_localization_ros2) - 上机定位栈 (NDT_OMP + RViz /initialpose, ROS2 Humble)
+- [rsasaki0109/ndt_omp_ros2](https://github.com/rsasaki0109/ndt_omp_ros2) - NDT_OMP backend
+- [gisbi-kim/scancontext-pybind](https://github.com/gisbi-kim/scancontext-pybind) - ScanContext++ Python 绑定 (auto_init_pose 用它做 place recognition)

--- a/FAST_LIO_SAM/config/airy_no_loop.yaml
+++ b/FAST_LIO_SAM/config/airy_no_loop.yaml
@@ -1,11 +1,7 @@
-# RoboSense Airy 192/96 线 - 原生 PointXYZIRT 路径 (lidar_type=5).
-# 直接订阅 rslidar_sdk 的 /rslidar_points + /rslidar_imu_data,
-# 不再需要 airy_bridge.
-#
-# 前提: rslidar_sdk 编译时 POINT_TYPE=XYZIRT + ENABLE_IMU_DATA_PARSE=ON.
-#
-# 用法:
-#   ros2 launch fast_lio_sam mapping_airy.launch.py
+# RoboSense Airy - 真实工厂外参 (从 DIFOP raw_captures 解析).
+# q (xyzw) = (-0.704655, +0.709540, -0.003130, -0.002010)
+# T (m)    = (+0.004250, +0.004180, -0.004460)
+# 关回环, 关在线外参估计, 不抽稀 (point_filter_num=1).
 /**:
   ros__parameters:
     publish:
@@ -15,7 +11,7 @@
       scan_bodyframe_pub_en: false
 
     common:
-      lid_topic: "/rslidar_points"     # 原生订阅, 无需 bridge
+      lid_topic: "/rslidar_points"
       imu_topic: "/rslidar_imu_data"
       time_sync_en: false
       data_mode: 0
@@ -24,10 +20,10 @@
 
     preprocess:
       blind: 0.5
-      lidar_type: 5                    # RSLIDAR_NEW (PointXYZIRT, double timestamp)
-      scan_line: 96                    # Airy 96-channel 模式; 192 模式时改 192
+      lidar_type: 5
+      scan_line: 96
       scan_rate: 10
-      livox_type: 1                    # 不用, 占位
+      livox_type: 1
 
     mapping:
       acc_cov: 0.1
@@ -36,11 +32,11 @@
       b_gyr_cov: 0.0001
       fov_degree: 360.0
       det_range: 60.0
-      extrinsic_est_en: true            # 外参在线估计 (无 DIFOP 真值时)
-      extrinsic_T: [0.0, 0.0, 0.0]
-      extrinsic_R: [1.0, 0.0, 0.0,
-                    0.0, 1.0, 0.0,
-                    0.0, 0.0, 1.0]
+      extrinsic_est_en: false
+      extrinsic_T: [0.004250, 0.004180, -0.004460]
+      extrinsic_R: [-0.006915, -0.999975,  0.001559,
+                    -0.999950,  0.006903, -0.007273,
+                     0.007262, -0.001609, -0.999972]
       extrinT_Gnss2Lidar: [0.0, 0.0, 0.0]
       extrinR_Gnss2Lidar: [1.0, 0.0, 0.0,
                            0.0, 1.0, 0.0,
@@ -51,7 +47,7 @@
       interval: -1
 
     feature_extract_enable: false
-    point_filter_num: 4               # Airy 单帧 ~86k 点, 取 1/4 减算力
+    point_filter_num: 1
     max_iteration: 4
     filter_size_corner: 0.3
     filter_size_surf: 0.3
@@ -69,14 +65,13 @@
     numberOfCores: 4
     mappingProcessInterval: 0.15
 
-    # 关键帧 (SAM)
     surroundingkeyframeAddingDistThreshold: 1.0
     surroundingkeyframeAddingAngleThreshold: 0.2
     surroundingKeyframeDensity: 2.0
     surroundingKeyframeSearchRadius: 50.0
 
-    # 回环检测 (SAM/PGO)
-    loopClosureEnableFlag: true
+    # 关回环 (纯 LIO)
+    loopClosureEnableFlag: false
     loopClosureFrequency: 1.0
     surroundingKeyframeSize: 50
     historyKeyframeSearchRadius: 15.0
@@ -84,13 +79,11 @@
     historyKeyframeSearchNum: 25
     historyKeyframeFitnessScore: 0.3
 
-    # GPS
     useImuHeadingInitialization: false
     useGpsElevation: false
     gpsCovThreshold: 2.0
     poseCovThreshold: 25.0
 
-    # 可视化
     globalMapVisualizationSearchRadius: 1000.0
     globalMapVisualizationPoseDensity: 10.0
     globalMapVisualizationLeafSize: 1.0

--- a/FAST_LIO_SAM/config/airy_test_no_extr_est.yaml
+++ b/FAST_LIO_SAM/config/airy_test_no_extr_est.yaml
@@ -1,0 +1,104 @@
+# RoboSense Airy 192/96 线 - 原生 PointXYZIRT 路径 (lidar_type=5).
+# 直接订阅 rslidar_sdk 的 /rslidar_points + /rslidar_imu_data,
+# 不再需要 airy_bridge.
+#
+# 前提: rslidar_sdk 编译时 POINT_TYPE=XYZIRT + ENABLE_IMU_DATA_PARSE=ON.
+#
+# 用法:
+#   ros2 launch fast_lio_sam mapping_airy.launch.py
+/**:
+  ros__parameters:
+    publish:
+      path_en: true
+      scan_publish_en: true
+      dense_publish_en: true
+      scan_bodyframe_pub_en: false
+
+    common:
+      lid_topic: "/rslidar_points"     # 原生订阅, 无需 bridge
+      imu_topic: "/rslidar_imu_data"
+      time_sync_en: false
+      data_mode: 0
+      bag_path: ""
+      gnss_topic: "/gps/fix"
+
+    preprocess:
+      blind: 0.5
+      lidar_type: 5                    # RSLIDAR_NEW (PointXYZIRT, double timestamp)
+      scan_line: 96                    # Airy 96-channel 模式; 192 模式时改 192
+      scan_rate: 10
+      livox_type: 1                    # 不用, 占位
+
+    mapping:
+      acc_cov: 0.1
+      gyr_cov: 0.1
+      b_acc_cov: 0.0001
+      b_gyr_cov: 0.0001
+      fov_degree: 360.0
+      det_range: 60.0
+      extrinsic_est_en: false            # 外参在线估计 (无 DIFOP 真值时)
+      # 真实外参 (IMU 装反 z 向下, LiDAR 朝上, ~180° 翻转).
+      # identity 是错的, ba 会爆炸到 +2.7 m/s² 导致几公里漂移.
+      extrinsic_T: [0.00425, 0.00418, -0.00446]
+      extrinsic_R: [-0.006915, -0.999975,  0.001559,
+                    -0.999950,  0.006903, -0.007273,
+                     0.007262, -0.001609, -0.999972]
+      extrinT_Gnss2Lidar: [0.0, 0.0, 0.0]
+      extrinR_Gnss2Lidar: [1.0, 0.0, 0.0,
+                           0.0, 1.0, 0.0,
+                           0.0, 0.0, 1.0]
+
+    pcd_save:
+      pcd_save_en: true
+      interval: -1
+
+    feature_extract_enable: false
+    point_filter_num: 4               # Airy 单帧 ~86k 点, 取 1/4 减算力
+    max_iteration: 4
+    filter_size_corner: 0.3
+    filter_size_surf: 0.3
+    filter_size_map: 0.3
+    cube_side_length: 1000.0
+    runtime_pos_log_enable: false
+    map_file_path: ""
+
+    odometrySurfLeafSize: 0.2
+    mappingCornerLeafSize: 0.1
+    mappingSurfLeafSize: 0.2
+    z_tollerance: 1000.0
+    rotation_tollerance: 1000.0
+
+    numberOfCores: 4
+    mappingProcessInterval: 0.15
+
+    # 关键帧 (SAM)
+    surroundingkeyframeAddingDistThreshold: 1.0
+    surroundingkeyframeAddingAngleThreshold: 0.2
+    surroundingKeyframeDensity: 2.0
+    surroundingKeyframeSearchRadius: 50.0
+
+    # 回环检测 (SAM/PGO)
+    loopClosureEnableFlag: true
+    loopClosureFrequency: 1.0
+    surroundingKeyframeSize: 50
+    historyKeyframeSearchRadius: 15.0
+    historyKeyframeSearchTimeDiff: 30.0
+    historyKeyframeSearchNum: 5      # 25 submap 污染 drift, 2 太稀; 5 平衡
+    historyKeyframeFitnessScore: 0.02    # ICP 平均平方残差阈值 (m²); 0.02 ≈ 14cm RMS, 拒绝 cross-region 错配
+
+    # GPS
+    useImuHeadingInitialization: false
+    useGpsElevation: false
+    gpsCovThreshold: 2.0
+    poseCovThreshold: 25.0
+
+    # 可视化
+    globalMapVisualizationSearchRadius: 1000.0
+    globalMapVisualizationPoseDensity: 10.0
+    globalMapVisualizationLeafSize: 1.0
+
+    visulize_IkdtreeMap: false
+    recontructKdTree: true
+
+    savePCD: true
+    savePCDDirectory: "/Downloads/LOAM/"

--- a/FAST_LIO_SAM/launch/mapping_airy.launch.py
+++ b/FAST_LIO_SAM/launch/mapping_airy.launch.py
@@ -8,7 +8,7 @@ fast-lio-sam 实时建图 launch (RoboSense Airy, 原生 PointXYZIRT 路径).
 
   # bag 回放 (use mapping_bag.launch.py instead):
   ros2 launch fast_lio_sam mapping_bag.launch.py \\
-       bag:=<path> config_file:=<...>/airy.yaml
+       bag:=<path> config_file:=<...>/airy_test_no_extr_est.yaml
 """
 import os
 
@@ -23,7 +23,7 @@ from launch_ros.actions import Node
 
 def generate_launch_description():
     pkg_share = get_package_share_directory('fast_lio_sam')
-    default_cfg = os.path.join(pkg_share, 'config', 'airy.yaml')
+    default_cfg = os.path.join(pkg_share, 'config', 'airy_test_no_extr_est.yaml')
     default_rviz = os.path.join(pkg_share, 'rviz_cfg', 'fastlio_hk.rviz')
 
     arg_use_sim_time = DeclareLaunchArgument(
@@ -32,7 +32,7 @@ def generate_launch_description():
     )
     arg_config = DeclareLaunchArgument(
         'config_file', default_value=default_cfg,
-        description='YAML 配置 (默认 airy.yaml)'
+        description='YAML 配置 (默认 airy_test_no_extr_est.yaml, 含真实 IMU↔LiDAR 外参)'
     )
     arg_rviz = DeclareLaunchArgument(
         'rviz', default_value='true',

--- a/FAST_LIO_SAM/launch/mapping_bag.launch.py
+++ b/FAST_LIO_SAM/launch/mapping_bag.launch.py
@@ -13,7 +13,7 @@ fast-lio-sam rosbag2 回放建图 launch (任意 ROS2 LiDAR bag).
 用法:
   ros2 launch fast_lio_sam mapping_bag.launch.py \\
       bag:=/path/to/rosbag2_dir \\
-      config_file:=/path/to/airy_via_bridge.yaml \\
+      config_file:=/path/to/airy_test_no_extr_est.yaml \\
       stop_service:=airy-lidar.service \\
       rate:=1.0
 

--- a/FAST_LIO_SAM/launch/mapping_velodyne16.launch.py
+++ b/FAST_LIO_SAM/launch/mapping_velodyne16.launch.py
@@ -32,7 +32,7 @@ def generate_launch_description():
     )
     arg_config = DeclareLaunchArgument(
         'config_file', default_value=default_cfg,
-        description='YAML 配置 (可换 mid360.yaml / airy.yaml 等)'
+        description='YAML 配置 (可换 mid360.yaml / airy_test_no_extr_est.yaml 等)'
     )
     arg_rviz = DeclareLaunchArgument(
         'rviz', default_value='true',

--- a/FAST_LIO_SAM/src/IMU_Processing.hpp
+++ b/FAST_LIO_SAM/src/IMU_Processing.hpp
@@ -197,12 +197,34 @@ void ImuProcess::IMU_init(const MeasureGroup& meas, esekfom::esekf<state_ikfom, 
         N++;
     }
     state_ikfom init_state = kf_state.get_x();  // 初始状态量
-    init_state.grav = S2(-mean_acc / mean_acc.norm() *
-                         G_m_s2);  // - acc * (g / acc)，负值，根据加速度均值，重力模长做归一化，重力记为S2流形
-    // init_state.grav = S2(V3D(0, 0, -1)*G_m_s2);
-
-    // init_state.rot = Exp(mean_acc.cross(V3D(0, 0, -1 / G_m_s2))).inverse();
-    // init_state.rot = GetRotByAlignVector(mean_acc, V3D(0, 0, -1));
+    // 让 world frame 用标准 z-up 约定 (跟 ROS / RViz / Nav2 一致, 不受 IMU 装反影响).
+    // 旧做法: init.rot=I, grav=-mean_acc/|mean_acc|*G; 直接继承 IMU body 方向, IMU 装反时 world +z 朝下.
+    // 新做法: 构造 init.rot 把 body 的"anti-gravity 方向" (=静止时 acc 方向) 旋到 world (0,0,+1);
+    //         grav 固定 (0,0,-G), 标准 z-up. EKF 数学等价但输出系是 z-up.
+    {
+        V3D up_body = mean_acc.normalized();   // 静止时 acc reading = -gravity_body = world +z direction in body frame
+        V3D z_world(0, 0, 1);
+        V3D axis = up_body.cross(z_world);
+        double s_axis = axis.norm();
+        double c_axis = up_body.dot(z_world);
+        M3D R_init;
+        if (s_axis < 1e-9) {
+            // up_body 已经跟 z_world 同向或反向
+            if (c_axis > 0)
+                R_init = M3D::Identity();
+            else
+                R_init = (M3D() << 1, 0, 0, 0, -1, 0, 0, 0, -1).finished();  // 180° around x
+        } else {
+            axis /= s_axis;
+            M3D K;
+            K <<      0,  -axis(2),   axis(1),
+                 axis(2),         0,  -axis(0),
+                -axis(1),   axis(0),         0;
+            R_init = M3D::Identity() + s_axis * K + (1 - c_axis) * (K * K);
+        }
+        init_state.rot = SO3(R_init);
+        init_state.grav = S2(V3D(0, 0, -G_m_s2));  // 标准 z-up
+    }
     init_state.bg = mean_gyr;                   // 初始化陀螺仪bias（初值？）为平均角速度
     init_state.offset_T_L_I = Lidar_T_wrt_IMU;  //   t_lidar_imu  translate外参
     init_state.offset_R_L_I = Lidar_R_wrt_IMU;  //   R_lidar_imu rotation 外参

--- a/FAST_LIO_SAM/src/laserMapping.cpp
+++ b/FAST_LIO_SAM/src/laserMapping.cpp
@@ -612,9 +612,9 @@ void addOdomFactor() {
         // 变量节点设置初始值
         initialEstimate.insert(0, trans2gtsamPose(transformTobeMapped));
     } else {
-        // 添加激光里程计因子
+        // 添加激光里程计因子. xy 7cm std, z 7cm std (回到对称, v3 z 放松反而让 xy 也飘).
         gtsam::noiseModel::Diagonal::shared_ptr odometryNoise =
-            gtsam::noiseModel::Diagonal::Variances((gtsam::Vector(6) << 1e-6, 1e-6, 1e-6, 1e-4, 1e-4, 1e-4).finished());
+            gtsam::noiseModel::Diagonal::Variances((gtsam::Vector(6) << 1e-5, 1e-5, 1e-5, 5e-3, 5e-3, 5e-3).finished());
         gtsam::Pose3 poseFrom = pclPointTogtsamPose3(cloudKeyPoses6D->points.back());  /// pre
         gtsam::Pose3 poseTo = trans2gtsamPose(transformTobeMapped);                    // cur
         // 参数：前一帧id，当前帧id，前一帧与当前帧的位姿变换（作为观测值），噪声协方差
@@ -996,9 +996,14 @@ void performLoopClosure() {
             publishCloud(pubHistoryKeyFrames, prevKeyframeCloud, timeLaserInfoStamp, odometryFrame);
     }
 
-    // ICP Settings
+    // ICP Settings.
+    // 原本 setMaxCorrespondenceDistance(150) 是 giseop 留给大尺度场景的, 但在 FAST-LIO
+    // 有 ~3m drift 时, 150m 让 ICP 把 cur 帧的点匹配到 prev 子图里完全错的对应,
+    // 看上去 fitness OK 实际 align 偏 3m, 再加上 loop noise 用 fitness × 6 (= 31° 旋转
+    // std), GTSAM 几乎忽略这种 loop, 出现重影.
+    // 5m 经验值: 既能 cover 几米 drift, 又不会跨房间错配.
     pcl::IterativeClosestPoint<PointType, PointType> icp;
-    icp.setMaxCorrespondenceDistance(150);  // giseop , use a value can cover 2*historyKeyframeSearchNum range in meter
+    icp.setMaxCorrespondenceDistance(5.0);
     icp.setMaximumIterations(100);
     icp.setTransformationEpsilon(1e-6);
     icp.setEuclideanFitnessEpsilon(1e-6);
@@ -1035,11 +1040,23 @@ void performLoopClosure() {
     gtsam::Pose3 poseFrom = gtsam::Pose3(gtsam::Rot3::RzRyRx(roll, pitch, yaw), gtsam::Point3(x, y, z));
     // 闭环匹配帧的位姿
     gtsam::Pose3 poseTo = pclPointTogtsamPose3(copy_cloudKeyPoses6D->points[loopKeyPre]);
+    // Loop noise: GTSAM Pose3 noise 顺序 (rx, ry, rz, x, y, z), 单位 rad²/m².
     gtsam::Vector Vector6(6);
-    float noiseScore = icp.getFitnessScore();  //  loop_clousre  noise from icp
-    Vector6 << noiseScore, noiseScore, noiseScore, noiseScore, noiseScore, noiseScore;
+    float noiseScore = icp.getFitnessScore();
+    float trans_var = std::max(noiseScore, 1e-4f);  // floor 1cm std
+    float rot_var   = 1e-6f;                        // ~0.057° std
+    Vector6 << rot_var, rot_var, rot_var, trans_var, trans_var, trans_var;
     gtsam::noiseModel::Diagonal::shared_ptr constraintNoise = gtsam::noiseModel::Diagonal::Variances(Vector6);
-    std::cout << "loopNoiseQueue   =   " << noiseScore << std::endl;
+    // 详细 log: 闭哪两个 KF + ICP 出的相对 z 差 + 时间差
+    float dz_icp = correctionLidarFrame(2, 3);
+    float dt_kf = (copy_cloudKeyPoses6D->points[loopKeyCur].time - copy_cloudKeyPoses6D->points[loopKeyPre].time);
+    std::cout << "LOOP cur=" << loopKeyCur << " <-> pre=" << loopKeyPre
+              << "  dt=" << dt_kf << "s"
+              << "  fitness=" << noiseScore
+              << "  dz_correction=" << dz_icp
+              << "  curZ=" << copy_cloudKeyPoses6D->points[loopKeyCur].z
+              << " preZ=" << copy_cloudKeyPoses6D->points[loopKeyPre].z
+              << std::endl;
 
     // 添加闭环因子需要的数据
     mtx.lock();


### PR DESCRIPTION
## Summary

跑 airy bag (RoboSense Airy LiDAR + 机器狗) 时发现三个 root cause:

1. **trajectory 飞到几公里 bbox** — yaml 用 identity 外参，IMU 装反时 EKF \`state.ba\` 5s 内爆炸到 +2.7 m/s²
2. **加 loop closure 后仍有重影** — submap 含 25 邻居 KF 把 drift 污染进 ICP target
3. **raw fastlio 输出 z 朝下** — world frame 继承 IMU body 朝向，IMU 装反时跟 ROS 约定反

## 修复分层

### A. 通用 fastlio 默认值问题
- ICP \`setMaxCorrespondenceDistance\` 150→5
- Loop noise 拆分: rot=1e-6, trans=max(fitness, 1e-4)（原来 \`Vector6 << fitness×6\` 旋转 std 高达 31°）
- Odom edge noise 1e-4→5e-3（默认 1cm std 太紧）
- \`historyKeyframeSearchNum\` 25→5（**最隐蔽 bug**，submap 污染）
- \`historyKeyframeFitnessScore\` 0.3→0.02
- z-up convention fix (IMU_init 用 Rodrigues 把 body-up 旋到 world +z)

### B. Airy LiDAR 特定
- 删除 \`airy.yaml\` (identity 外参 = bug 源头)
- \`airy_test_no_extr_est.yaml\` 注入真实外参 (180° flip 矩阵)
- launch 默认 yaml 切换

### C. Airy 装机器狗特定
- odom noise 放松对高振动平台是绝对必须 (不是 nice-to-have)
- submap=5 对"停下来转一圈"采集 mode 特别关键

## A/B 测试 (airy_20260525_000454, 出→进→出 365s, 同一外面点 KF 11 vs KF 32)

| 配置 | xy drift | z drift |
|------|----------|---------|
| 原始默认 | 25 cm | 58 cm (重影) |
| 仅 loop noise 拆分 | 5 cm | 39 cm |
| + submap=5 + fit=0.02 (本 PR) | **8.5 cm** | **2.7 cm** ✅ |

详细分析见 CLAUDE.md 新增的「2026-05-26 修复总集」一节。

## Test plan

- [x] airy_20260525_000454 bag 跑通, 2D map 无重影
- [x] 老 bag airy_20260510_175730 也回归测试通过
- [x] trajectory z 平面对齐 (KF 0→38 dz 2.6cm vs 原 70cm)
- [x] /Odometry topic 现在原生 z-up
- [ ] 跑跑跳跳更激烈的 bag (留待下次, 可能需调 acc_cov / gyr_cov)

🤖 Generated with [Claude Code](https://claude.com/claude-code)