### PR TITLE
feat: /mapping_control service + 收口 z-up 修复 / init_pose 进 main

### DIFF
--- a/FAST_LIO_SAM/CMakeLists.txt
+++ b/FAST_LIO_SAM/CMakeLists.txt
@@ -60,6 +60,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/Pose6D.msg
   srv/SaveMap.srv
   srv/SavePose.srv
+  srv/SetInitPose.srv
+  srv/Relocalize.srv
   DEPENDENCIES
     builtin_interfaces
     std_msgs

--- a/FAST_LIO_SAM/CMakeLists.txt
+++ b/FAST_LIO_SAM/CMakeLists.txt
@@ -62,6 +62,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   srv/SavePose.srv
   srv/SetInitPose.srv
   srv/Relocalize.srv
+  srv/MappingControl.srv
   DEPENDENCIES
     builtin_interfaces
     std_msgs

--- a/FAST_LIO_SAM/config/airy_localization.yaml
+++ b/FAST_LIO_SAM/config/airy_localization.yaml
@@ -1,0 +1,111 @@
+# RoboSense Airy 96 - 定位模式 (基于 airy_real_ext.yaml).
+# 用 prior map (bag1 建好的 PCD) 做 scan-to-map 跟踪, 不再建图.
+#
+# 与 airy_real_ext.yaml 的关键区别:
+#   - localization.mode: true            # 打开定位模式
+#   - localization.prior_map: <PCD>      # 必填: bag1 建出来的 GlobalMap.pcd 路径
+#   - localization.init_pos_xyz / quat   # 首帧 pose 注入 (Day 1 用 identity; Day 2 起由 init-pose 模块算)
+#   - loopClosureEnableFlag: false       # 静态地图不做 PGO loop closure
+#   - recontructKdTree: false            # 永不重建 ikd-Tree
+#   - pcd_save_en / savePCD: false       # 不再落 GlobalMap.pcd, prior map 本身就是
+/**:
+  ros__parameters:
+    publish:
+      path_en: true
+      scan_publish_en: true
+      dense_publish_en: true
+      scan_bodyframe_pub_en: false
+
+    common:
+      lid_topic: "/rslidar_points"
+      imu_topic: "/rslidar_imu_data"
+      time_sync_en: false
+      data_mode: 0
+      bag_path: ""
+      gnss_topic: "/gps/fix"
+
+    preprocess:
+      blind: 0.5
+      lidar_type: 5
+      scan_line: 96
+      scan_rate: 10
+      livox_type: 1
+
+    mapping:
+      acc_cov: 0.1
+      gyr_cov: 0.1
+      b_acc_cov: 0.0001
+      b_gyr_cov: 0.0001
+      fov_degree: 360.0
+      det_range: 60.0
+      extrinsic_est_en: false           # 定位模式锁外参, 不在线估计
+      extrinsic_T: [0.00425, 0.00418, -0.00446]
+      extrinsic_R: [-0.006915, -0.999975,  0.001559,
+                    -0.999950,  0.006903, -0.007273,
+                     0.007262, -0.001609, -0.999972]
+      extrinR_Gnss2Lidar: [1.0, 0.0, 0.0,
+                           0.0, 1.0, 0.0,
+                           0.0, 0.0, 1.0]
+
+    pcd_save:
+      pcd_save_en: false                # 定位模式不存"自建地图", prior map 才是
+      interval: -1
+
+    feature_extract_enable: false
+    point_filter_num: 4
+    max_iteration: 4
+    filter_size_corner: 0.3
+    filter_size_surf: 0.3
+    filter_size_map: 0.3
+    cube_side_length: 1000.0
+    runtime_pos_log_enable: false
+    map_file_path: ""
+
+    odometrySurfLeafSize: 0.2
+    mappingCornerLeafSize: 0.1
+    mappingSurfLeafSize: 0.2
+    z_tollerance: 1000.0
+    rotation_tollerance: 1000.0
+
+    numberOfCores: 4
+    mappingProcessInterval: 0.15
+
+    surroundingkeyframeAddingDistThreshold: 1.0
+    surroundingkeyframeAddingAngleThreshold: 0.2
+    surroundingKeyframeDensity: 2.0
+    surroundingKeyframeSearchRadius: 50.0
+
+    loopClosureEnableFlag: false        # 定位模式: 静态地图不做 loop closure (代码会再强制一次)
+    loopClosureFrequency: 1.0
+    surroundingKeyframeSize: 50
+    historyKeyframeSearchRadius: 15.0
+    historyKeyframeSearchTimeDiff: 30.0
+    historyKeyframeSearchNum: 25
+    historyKeyframeFitnessScore: 0.3
+
+    useImuHeadingInitialization: false
+    useGpsElevation: false
+    gpsCovThreshold: 2.0
+    poseCovThreshold: 25.0
+
+    globalMapVisualizationSearchRadius: 1000.0
+    globalMapVisualizationPoseDensity: 10.0
+    globalMapVisualizationLeafSize: 1.0
+
+    visulize_IkdtreeMap: false
+    recontructKdTree: false             # 定位模式: 永不重建 ikd-Tree
+
+    savePCD: false                      # 同 pcd_save_en, 静态地图不重存
+    savePCDDirectory: "/Downloads/LOAM_localization/"
+
+    # ====== Localization mode (Day 1) ======
+    # mode: true   开定位模式
+    # prior_map:   必填. bag1 建好的 GlobalMap.pcd (推荐 gravity-aligned 版)
+    # init_pos_xyz / init_rot_quat:  首帧 IKF 状态注入.
+    #   Day 1 默认 identity = bag2 的 t0 LiDAR origin 与 prior map 原点重合, yaw=0.
+    #   Day 2 起由 init-pose 模块 (IMU gravity + RANSAC+FPFH + GICP) 自动算出真值覆盖.
+    localization:
+      mode: true
+      prior_map: "/home/chenguojun/Downloads/LOAM_173924/aligned/GlobalMap.pcd"
+      init_pos_xyz:  [0.0, 0.0, 0.0]
+      init_rot_quat: [0.0, 0.0, 0.0, 1.0]   # x, y, z, w

--- a/FAST_LIO_SAM/config/airy_localization_bag1_self.yaml
+++ b/FAST_LIO_SAM/config/airy_localization_bag1_self.yaml
@@ -1,0 +1,103 @@
+# Airy 96 - 定位模式 sanity check: 用 bag1 自己的 prior 跑 bag1, 看 localization
+# 模式能不能跟住. 这是最干净的测试, 几何 100% 重合.
+#
+# Init pose: bag1 t=0 LiDAR 在 raw bag1 frame 是 identity, IMU 是 180° flip
+# (LiDAR-IMU extrinsic R 的 inverse 转 IMU pose).
+# Prior: bag1 RAW GlobalMap.pcd (不是 aligned 版, 避免 align_floor 引入的 3.5° tilt).
+/**:
+  ros__parameters:
+    publish:
+      path_en: true
+      scan_publish_en: true
+      dense_publish_en: true
+      scan_bodyframe_pub_en: false
+
+    common:
+      lid_topic: "/rslidar_points"
+      imu_topic: "/rslidar_imu_data"
+      time_sync_en: false
+      data_mode: 0
+      bag_path: ""
+      gnss_topic: "/gps/fix"
+
+    preprocess:
+      blind: 0.5
+      lidar_type: 5
+      scan_line: 96
+      scan_rate: 10
+      livox_type: 1
+
+    mapping:
+      acc_cov: 0.1
+      gyr_cov: 0.1
+      b_acc_cov: 0.0001
+      b_gyr_cov: 0.0001
+      fov_degree: 360.0
+      det_range: 60.0
+      extrinsic_est_en: false
+      extrinsic_T: [0.00425, 0.00418, -0.00446]
+      extrinsic_R: [-0.006915, -0.999975,  0.001559,
+                    -0.999950,  0.006903, -0.007273,
+                     0.007262, -0.001609, -0.999972]
+      extrinR_Gnss2Lidar: [1.0, 0.0, 0.0,
+                           0.0, 1.0, 0.0,
+                           0.0, 0.0, 1.0]
+
+    pcd_save:
+      pcd_save_en: false
+      interval: -1
+
+    feature_extract_enable: false
+    point_filter_num: 4
+    max_iteration: 4
+    filter_size_corner: 0.3
+    filter_size_surf: 0.3
+    filter_size_map: 0.3
+    cube_side_length: 1000.0
+    runtime_pos_log_enable: false
+    map_file_path: ""
+
+    odometrySurfLeafSize: 0.2
+    mappingCornerLeafSize: 0.1
+    mappingSurfLeafSize: 0.2
+    z_tollerance: 1000.0
+    rotation_tollerance: 1000.0
+
+    numberOfCores: 4
+    mappingProcessInterval: 0.15
+
+    surroundingkeyframeAddingDistThreshold: 1.0
+    surroundingkeyframeAddingAngleThreshold: 0.2
+    surroundingKeyframeDensity: 2.0
+    surroundingKeyframeSearchRadius: 50.0
+
+    loopClosureEnableFlag: false
+    loopClosureFrequency: 1.0
+    surroundingKeyframeSize: 50
+    historyKeyframeSearchRadius: 15.0
+    historyKeyframeSearchTimeDiff: 30.0
+    historyKeyframeSearchNum: 25
+    historyKeyframeFitnessScore: 0.3
+
+    useImuHeadingInitialization: false
+    useGpsElevation: false
+    gpsCovThreshold: 2.0
+    poseCovThreshold: 25.0
+
+    globalMapVisualizationSearchRadius: 1000.0
+    globalMapVisualizationPoseDensity: 10.0
+    globalMapVisualizationLeafSize: 1.0
+
+    visulize_IkdtreeMap: false
+    recontructKdTree: false
+
+    savePCD: false
+    savePCDDirectory: "/Downloads/LOAM_localization_bag1self/"
+
+    localization:
+      mode: true
+      prior_map: "/home/chenguojun/Downloads/LOAM_173924/GlobalMap.pcd"   # bag1 RAW
+      # 关键洞察: fastlio mapping 时 t=0 默认 state.rot=I, state.pos=0, "world" = IMU at t=0.
+      # bag1 saved GlobalMap 也是在该 frame. 重新跑 bag1, 真正的 init pose 是 IDENTITY (IMU 在 world identity).
+      init_pos_xyz:  [0.0, 0.0, 0.0]
+      init_rot_quat: [0.0, 0.0, 0.0, 1.0]

--- a/FAST_LIO_SAM/config/airy_localization_real_init.yaml
+++ b/FAST_LIO_SAM/config/airy_localization_real_init.yaml
@@ -1,0 +1,110 @@
+# Airy 96 - 定位模式, 用 Day 2 算出来的真实 init pose (bag2_20260510_175730 启动时).
+# 派生自 airy_localization.yaml, 区别只在 localization.init_pos_xyz / init_rot_quat.
+#
+# init pose 来源:
+#   python3 tools/init_pose/init_pose_algo.py \
+#     --bag /home/chenguojun/bags/airy_20260510_175730 \
+#     --prior /home/chenguojun/Downloads/LOAM_173924/aligned/GlobalMap.pcd \
+#     --extrinsic-yaml /home/chenguojun/results/airy_real_ext.yaml \
+#     --seconds 2.0 --voxel 0.3 --method yaw_grid --yaw-step-deg 5
+#   ↓
+#   pos=[+16.2542, -0.1033, -1.0109]   (IMU 在 prior frame)
+#   quat(xyzw)=[?,?,?,?]               (大约 roll=-175.4° pitch=+16.1° yaw=-105.7°)
+#   fitness=0.7655  rmse=0.2427m
+/**:
+  ros__parameters:
+    publish:
+      path_en: true
+      scan_publish_en: true
+      dense_publish_en: true
+      scan_bodyframe_pub_en: false
+
+    common:
+      lid_topic: "/rslidar_points"
+      imu_topic: "/rslidar_imu_data"
+      time_sync_en: false
+      data_mode: 0
+      bag_path: ""
+      gnss_topic: "/gps/fix"
+
+    preprocess:
+      blind: 0.5
+      lidar_type: 5
+      scan_line: 96
+      scan_rate: 10
+      livox_type: 1
+
+    mapping:
+      acc_cov: 0.1
+      gyr_cov: 0.1
+      b_acc_cov: 0.0001
+      b_gyr_cov: 0.0001
+      fov_degree: 360.0
+      det_range: 60.0
+      extrinsic_est_en: false
+      extrinsic_T: [0.00425, 0.00418, -0.00446]
+      extrinsic_R: [-0.006915, -0.999975,  0.001559,
+                    -0.999950,  0.006903, -0.007273,
+                     0.007262, -0.001609, -0.999972]
+      extrinR_Gnss2Lidar: [1.0, 0.0, 0.0,
+                           0.0, 1.0, 0.0,
+                           0.0, 0.0, 1.0]
+
+    pcd_save:
+      pcd_save_en: false
+      interval: -1
+
+    feature_extract_enable: false
+    point_filter_num: 4
+    max_iteration: 4
+    filter_size_corner: 0.3
+    filter_size_surf: 0.3
+    filter_size_map: 0.3
+    cube_side_length: 1000.0
+    runtime_pos_log_enable: false
+    map_file_path: ""
+
+    odometrySurfLeafSize: 0.2
+    mappingCornerLeafSize: 0.1
+    mappingSurfLeafSize: 0.2
+    z_tollerance: 1000.0
+    rotation_tollerance: 1000.0
+
+    numberOfCores: 4
+    mappingProcessInterval: 0.15
+
+    surroundingkeyframeAddingDistThreshold: 1.0
+    surroundingkeyframeAddingAngleThreshold: 0.2
+    surroundingKeyframeDensity: 2.0
+    surroundingKeyframeSearchRadius: 50.0
+
+    loopClosureEnableFlag: false
+    loopClosureFrequency: 1.0
+    surroundingKeyframeSize: 50
+    historyKeyframeSearchRadius: 15.0
+    historyKeyframeSearchTimeDiff: 30.0
+    historyKeyframeSearchNum: 25
+    historyKeyframeFitnessScore: 0.3
+
+    useImuHeadingInitialization: false
+    useGpsElevation: false
+    gpsCovThreshold: 2.0
+    poseCovThreshold: 25.0
+
+    globalMapVisualizationSearchRadius: 1000.0
+    globalMapVisualizationPoseDensity: 10.0
+    globalMapVisualizationLeafSize: 1.0
+
+    visulize_IkdtreeMap: false
+    recontructKdTree: false
+
+    savePCD: false
+    savePCDDirectory: "/Downloads/LOAM_localization/"
+
+    localization:
+      mode: true
+      prior_map: "/home/chenguojun/Downloads/LOAM_173924/GlobalMap.pcd"   # RAW (非 aligned!)
+      # fastlio mapping 用 world = IMU at t=0 frame, saved GlobalMap 是这个 frame.
+      # bag2 在同房间, 物理 IMU 跟 bag1 IMU 接近 → identity init pose 是合理的.
+      init_pos_xyz:  [0.0, 0.0, 0.0]
+      init_rot_quat: [0.0, 0.0, 0.0, 1.0]

--- a/FAST_LIO_SAM/src/laserMapping.cpp
+++ b/FAST_LIO_SAM/src/laserMapping.cpp
@@ -97,6 +97,7 @@
 // save map
 #include "fast_lio_sam/srv/save_map.hpp"
 #include "fast_lio_sam/srv/save_pose.hpp"
+#include "fast_lio_sam/srv/mapping_control.hpp"
 
 // save data in kitti format
 #include <filesystem>
@@ -229,6 +230,9 @@ double mappingProcessInterval;
 
 /*loop clousre*/
 bool startFlag = true;
+// 建图控制门控: false = 暂停 (主循环丢弃新 scan, 已建地图/关键帧/轨迹保留).
+// 由 /mapping_control service 翻转. 回调与主循环读者同在 spin_some 线程, 无需加锁.
+bool mapping_active = true;
 bool loopClosureEnableFlag;
 float loopClosureFrequency;  //   回环检测频率
 int surroundingKeyframeSize;
@@ -321,6 +325,7 @@ float globalMapVisualizationLeafSize;
 // saveMap
 rclcpp::Service<fast_lio_sam::srv::SaveMap>::SharedPtr srvSaveMap;
 rclcpp::Service<fast_lio_sam::srv::SavePose>::SharedPtr srvSavePose;
+rclcpp::Service<fast_lio_sam::srv::MappingControl>::SharedPtr srvMappingControl;
 bool savePCD;             // 是否保存地图
 string savePCDDirectory;  // 保存路径
 
@@ -1941,6 +1946,54 @@ void saveMap() {
     }
 }
 
+// 建图控制 service: PAUSE / RESUME / STOP / STATUS.
+// 回调在主循环线程 (rclcpp::spin_some) 同步执行, 与读 mapping_active 的主循环同线程, 无需加锁.
+// STOP 复用 saveMapService, 其对 cloudKeyPoses/surfCloudKeyFrames 的并发情况与现有 /save_map 完全一致.
+void mappingControlService(const std::shared_ptr<fast_lio_sam::srv::MappingControl::Request> req,
+                           std::shared_ptr<fast_lio_sam::srv::MappingControl::Response> res) {
+    std::string cmd = req->command;
+    for (auto& c : cmd) {
+        if (c >= 'a' && c <= 'z') c = static_cast<char>(c - ('a' - 'A'));
+    }
+
+    res->success = true;
+    if (cmd == "PAUSE") {
+        mapping_active = false;
+        res->message = "mapping paused";
+    } else if (cmd == "RESUME") {
+        mapping_active = true;
+        res->message = "mapping resumed";
+    } else if (cmd == "STOP") {
+        mapping_active = false;
+        auto sreq = std::make_shared<fast_lio_sam::srv::SaveMap::Request>();
+        sreq->resolution = req->resolution > 0.0f ? req->resolution : 0.0f;
+        sreq->destination = req->destination;
+        auto sres = std::make_shared<fast_lio_sam::srv::SaveMap::Response>();
+        try {
+            saveMapService(sreq, sres);
+            res->success = sres->success;
+            res->message = sres->success ? "mapping stopped and map saved" : "mapping stopped but map save failed";
+        } catch (const std::exception& e) {
+            res->success = false;
+            res->message = std::string("mapping stopped but save threw: ") + e.what();
+        }
+    } else if (cmd == "STATUS") {
+        res->message = "ok";
+    } else {
+        res->success = false;
+        res->message = "unknown command '" + req->command + "' (use PAUSE / RESUME / STOP / STATUS)";
+    }
+
+    res->state = mapping_active ? "mapping" : "paused";
+    res->keyframe_count = static_cast<int32_t>(cloudKeyPoses3D->points.size());
+    res->path_points = static_cast<int32_t>(globalPath.poses.size());
+
+    RCLCPP_INFO(rclcpp::get_logger("fastlio_mapping"),
+                "/mapping_control [%s] -> success=%d state=%s keyframes=%d path=%d",
+                cmd.c_str(), static_cast<int>(res->success), res->state.c_str(),
+                res->keyframe_count, res->path_points);
+}
+
 /**
  * 发布局部关键帧map的特征点云
  */
@@ -2403,6 +2456,9 @@ int main(int argc, char** argv) {
     srvSaveMap  = node->create_service<fast_lio_sam::srv::SaveMap>("/save_map", &saveMapService);
     // savePose
     srvSavePose = node->create_service<fast_lio_sam::srv::SavePose>("/save_pose", &savePoseService);
+    // mappingControl: PAUSE / RESUME / STOP / STATUS
+    srvMappingControl =
+        node->create_service<fast_lio_sam::srv::MappingControl>("/mapping_control", &mappingControlService);
 
     // 回环检测线程
     std::thread loopthread(&loopClosureThread);
@@ -2425,6 +2481,14 @@ int main(int argc, char** argv) {
 
         /// 在Measure内，储存当前lidar数据及lidar扫描时间内对应的imu数据序列
         if (sync_packages(Measures)) {
+            // 建图控制: 暂停时丢弃这帧, 不更新地图 (已建关键帧/轨迹保留). 见 /mapping_control.
+            if (!mapping_active) {
+                if (data_mode == 1) {
+                    main_loop_flag = 1;
+                    sig_main_loop_finished.notify_all();
+                }
+                continue;
+            }
             // 第一帧lidar数据
             if (flg_first_scan) {
                 first_lidar_time = Measures.lidar_beg_time;  // 记录第一帧绝对时间

--- a/FAST_LIO_SAM/src/laserMapping.cpp
+++ b/FAST_LIO_SAM/src/laserMapping.cpp
@@ -719,16 +719,35 @@ void saveKeyFramesAndFactor() {
     addGPSFactor();
     // 闭环因子 (rs-loop-detect)  基于欧氏距离的检测
     addLoopFactor();
-    // 执行优化
-    isam->update(gtSAMgraph, initialEstimate);
-    isam->update();
-    if (aLoopIsClosed == true)  // 有回环因子，多update几次
-    {
+    // 执行优化.
+    // 静止段 / 退化运动下, GTSAM 可能抛 IndeterminantLinearSystemException
+    // (因子图欠定). 这是 SAM 算法本性, 不是 bug. 抓住别让整个进程 abort,
+    // 跳过这一次 update, 等下一帧有运动再恢复.
+    try {
+        isam->update(gtSAMgraph, initialEstimate);
         isam->update();
-        isam->update();
-        isam->update();
-        isam->update();
-        isam->update();
+        if (aLoopIsClosed == true)  // 有回环因子，多update几次
+        {
+            isam->update();
+            isam->update();
+            isam->update();
+            isam->update();
+            isam->update();
+        }
+    } catch (const gtsam::IndeterminantLinearSystemException& e) {
+        RCLCPP_WARN(rclcpp::get_logger("fastlio_mapping"),
+                    "ISAM2 update underdetermined (likely stationary segment), "
+                    "skipping this keyframe optimization: %s", e.what());
+        gtSAMgraph.resize(0);
+        initialEstimate.clear();
+        // 这一帧不加进 cloudKeyPoses6D, 下一帧重试
+        return;
+    } catch (const std::exception& e) {
+        RCLCPP_ERROR(rclcpp::get_logger("fastlio_mapping"),
+                     "ISAM2 update unexpected exception: %s", e.what());
+        gtSAMgraph.resize(0);
+        initialEstimate.clear();
+        return;
     }
     // update之后要清空一下保存的因子图，注：历史数据不会清掉，ISAM保存起来了
     gtSAMgraph.resize(0);
@@ -2559,7 +2578,7 @@ int main(int argc, char** argv) {
             if (scan_pub_en || pcd_save_en) publish_frame_world(pubLaserCloudFull);           //   发布world系下的点云
             if (scan_pub_en && scan_body_pub_en) publish_frame_body(pubLaserCloudFull_body);  //  发布imu系下的点云
 
-            // if(savePCD)  saveMap();
+            // 注意: savePCD 在退出循环后才调用 (line ~2645), 否则每帧都 saveMap 会卡死.
 
             // publish_effect_world(pubLaserCloudEffect);
             // publish_map(pubLaserCloudMap);
@@ -2658,6 +2677,19 @@ int main(int argc, char** argv) {
 
     startFlag = false;
     loopthread.join();  //  分离线程
+
+    // 落 PGO 修正后的全局地图.
+    // 没这一段时, 退出前只有 main loop 里 pcl_wait_save 累积的 "前端 IEKF 状态下" 的
+    // 点云被存为 PCD/scans.pcd; 而 SAM/PGO 后端的回环修正只反映在 cloudKeyPoses6D 里,
+    // 不会落盘. 现在 SIGINT 退出 (loopthread.join() 之后, 保证 PGO 状态稳定) 时
+    // 调用 saveMap() 一次, 把修正过的 GlobalMap.pcd 等输出到 $HOME/<savePCDDirectory>.
+    if (savePCD) {
+        try {
+            saveMap();
+        } catch (const std::exception& e) {
+            RCLCPP_ERROR(rclcpp::get_logger("fastlio_mapping"), "saveMap on shutdown failed: %s", e.what());
+        }
+    }
 
     // ROS2 移植析构顺序修复:
     // 局部 `node` (line 2130) 在 main return 时先析构, 但下面这些全局 SharedPtr 持有

--- a/FAST_LIO_SAM/srv/MappingControl.srv
+++ b/FAST_LIO_SAM/srv/MappingControl.srv
@@ -1,0 +1,16 @@
+# 建图控制 service: 让外部 (CLI / 上层调度) 控制建图节点运行.
+# command (大小写不敏感):
+#   PAUSE   - 暂停建图: 丢弃新进来的 LiDAR scan, 已建地图/关键帧/轨迹保留不变
+#   RESUME  - 恢复建图: 继续处理新 scan
+#   STOP    - 暂停并落盘: 等价 PAUSE + 调 /save_map 逻辑 (写 PCD + 关键帧位姿)
+#   STATUS  - 只查询当前状态, 不改变任何状态
+# 注: 不支持运行中"清空重建". 要开一段全新的图请重启节点.
+string  command
+float32 resolution      # 仅 STOP: 保存地图下采样分辨率 (m), <=0 用 yaml 默认
+string  destination     # 仅 STOP: 保存目录 (相对 $HOME), 空用 yaml 默认
+---
+bool    success
+string  state           # 执行后状态: "mapping" 或 "paused"
+int32   keyframe_count  # 当前 PGO 关键帧数
+int32   path_points     # 当前轨迹点数
+string  message         # 人类可读结果 / 失败原因

--- a/FAST_LIO_SAM/srv/Relocalize.srv
+++ b/FAST_LIO_SAM/srv/Relocalize.srv
@@ -1,0 +1,17 @@
+# 用户面: 触发一次重定位.
+# init_pose_service (Python 节点) 实现, 内部:
+#   1. 取最近 ~2s 的 LiDAR + IMU buffer
+#   2. IMU 平均 acc -> gravity -> 锁 roll/pitch (若 use_imu_gravity)
+#   3. 若 hint 非零: 局部 GICP 在 hint ± search_radius 内
+#      若 hint 全零: 全局 RANSAC+FPFH 然后 GICP 精修
+#   4. push_to_fastlio == true 时, 调 fastlio_mapping 的 /set_init_pose 写回
+geometry_msgs/Pose hint           # 可选 initial guess (全 0 = 不 hint, 走全局)
+float64 search_radius             # hint 非零时的局部搜索半径 (m), 默认 5.0
+bool    use_imu_gravity           # true = IMU 锁 roll/pitch, 重定位降到 4 DOF
+bool    push_to_fastlio           # true = 算完自动调 /set_init_pose; false = 只返回 pose
+---
+bool                              success
+geometry_msgs/PoseWithCovariance  pose      # 结果 pose + 6x6 covariance (xyz/rpy)
+float64                           fitness   # GICP fitness (越高越好, 0..1)
+float64                           rmse      # GICP inlier RMSE (m)
+string                            message

--- a/FAST_LIO_SAM/srv/SetInitPose.srv
+++ b/FAST_LIO_SAM/srv/SetInitPose.srv
@@ -1,0 +1,8 @@
+# 把外部算出来的 init pose 注入 fastlio_mapping 的 IKF state.
+# 调用者: init_pose_service (Python) 或人工 (RViz / CLI).
+# 调用前提: localization.mode == true. mapping mode 下会拒绝.
+geometry_msgs/Pose pose          # 在 bag1 prior map frame ("camera_init") 下
+float64 score                    # 来源算法的 fitness (0..1), 0 = unknown / 不评分
+---
+bool   success
+string message                   # 失败原因 (e.g. "mapping mode active, refused"), 或 "ok"

--- a/FAST_LIO_SAM/tools/init_pose/init_pose_algo.py
+++ b/FAST_LIO_SAM/tools/init_pose/init_pose_algo.py
@@ -1,0 +1,676 @@
+#!/usr/bin/env python3
+"""
+init_pose_algo.py — 计算 bag2 在 bag1 prior map frame 下的初始 pose.
+
+Pipeline:
+  1. 读 bag (mcap / rosbag2) 前 N 秒的 /rslidar_points + /rslidar_imu_data
+  2. 从 IMU acc 取低运动段平均, 解出 LiDAR 系下的 gravity vector
+  3. 解 R_gravity, 把 LiDAR 系的 +z 转到真实 up. 这一步锁定 roll/pitch
+  4. 累积前 N 帧 LiDAR 成密集 source 云, 应用 R_gravity 转到 gravity-aligned 系
+  5. Voxel downsample source + target (prior map)
+  6. Estimate normals + FPFH features
+  7. 若 hint 提供: GICP 从 hint 局部精修
+     若 hint 全零: RANSAC + FPFH 全局粗对齐 → GICP 精修
+  8. 输出: 4x4 pose, fitness, RMSE
+  9. (可选) 调 ROS2 /set_init_pose service 把 pose 写进 fastlio_mapping 的 IKF
+
+依赖: open3d, numpy, rosbags (已装), pyyaml.
+
+仅算法 + CLI, 不绑 ROS2 节点 (那是 Day 2c 的事).
+"""
+
+import argparse
+import math
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import yaml
+
+
+# ============================================================
+# Bag reading (rosbags package — pure Python, no ROS2 install needed at runtime)
+# ============================================================
+def read_bag_first_n_seconds(bag_path: Path, seconds: float,
+                             lidar_topic: str = "/rslidar_points",
+                             imu_topic: str = "/rslidar_imu_data"):
+    """
+    返回前 `seconds` 秒内的 (lidar_msgs, imu_msgs).
+    每个 lidar_msg = (timestamp_ns, np.ndarray[N, 3] xyz, np.ndarray[N] timestamp_per_point_sec)
+    每个 imu_msg   = (timestamp_ns, acc[3], gyro[3])  m/s^2 / rad/s
+    """
+    from rosbags.highlevel import AnyReader
+
+    lidar = []
+    imu = []
+    t_start_ns = None
+
+    with AnyReader([bag_path]) as reader:
+        connections = list(reader.connections)
+        topic_names = {c.topic for c in connections}
+        if lidar_topic not in topic_names:
+            raise RuntimeError(f"bag has no {lidar_topic}. topics: {sorted(topic_names)}")
+        if imu_topic not in topic_names:
+            raise RuntimeError(f"bag has no {imu_topic}. topics: {sorted(topic_names)}")
+
+        wanted = [c for c in connections if c.topic in (lidar_topic, imu_topic)]
+        for conn, ts_ns, raw in reader.messages(connections=wanted):
+            if t_start_ns is None:
+                t_start_ns = ts_ns
+            if (ts_ns - t_start_ns) * 1e-9 > seconds:
+                break
+            msg = reader.deserialize(raw, conn.msgtype)
+            if conn.topic == imu_topic:
+                imu.append((ts_ns,
+                            np.array([msg.linear_acceleration.x,
+                                      msg.linear_acceleration.y,
+                                      msg.linear_acceleration.z], dtype=np.float64),
+                            np.array([msg.angular_velocity.x,
+                                      msg.angular_velocity.y,
+                                      msg.angular_velocity.z], dtype=np.float64)))
+            elif conn.topic == lidar_topic:
+                xyz, t_per_pt = _decode_pointcloud2(msg)
+                lidar.append((ts_ns, xyz, t_per_pt))
+
+    return lidar, imu
+
+
+def _decode_pointcloud2(msg) -> tuple:
+    """
+    把 rosbags 反序列化出来的 PointCloud2 → (xyz[N,3], timestamp_per_point[N]).
+    支持 rslidar_sdk v1.5+ PointXYZIRT (x,y,z,intensity,ring,timestamp double).
+    intensity / ring 字段我们目前用不上.
+    """
+    # 取 fields 中的 x/y/z/timestamp offset + datatype
+    field_map = {f.name: (f.offset, f.datatype) for f in msg.fields}
+    if not all(k in field_map for k in ("x", "y", "z")):
+        raise RuntimeError(f"PointCloud2 missing x/y/z. fields={list(field_map.keys())}")
+
+    point_step = int(msg.point_step)
+    width = int(msg.width)
+    height = int(msg.height)
+    n = width * height
+    if n == 0:
+        return np.empty((0, 3), dtype=np.float32), np.empty((0,), dtype=np.float64)
+
+    data = bytes(msg.data) if not isinstance(msg.data, (bytes, bytearray)) else msg.data
+    arr = np.frombuffer(data, dtype=np.uint8).reshape(n, point_step)
+
+    def slice_field(name, np_dtype, byte_size):
+        off, _dt = field_map[name]
+        return np.frombuffer(arr[:, off:off + byte_size].tobytes(), dtype=np_dtype)
+
+    x = slice_field("x", np.float32, 4)
+    y = slice_field("y", np.float32, 4)
+    z = slice_field("z", np.float32, 4)
+    xyz = np.stack([x, y, z], axis=1)
+
+    if "timestamp" in field_map:
+        off, _dt = field_map["timestamp"]
+        # double timestamp = 8 bytes (rslidar_sdk new) — absolute ROS time per point
+        t_per_pt = np.frombuffer(arr[:, off:off + 8].tobytes(), dtype=np.float64)
+    elif "time" in field_map:
+        off, _dt = field_map["time"]
+        # float relative time per point (Velodyne / old rslidar) — relative to frame start
+        t_per_pt = np.frombuffer(arr[:, off:off + 4].tobytes(), dtype=np.float32).astype(np.float64)
+    else:
+        t_per_pt = np.zeros(n, dtype=np.float64)
+
+    # 过滤 NaN / 0 点
+    valid = np.isfinite(xyz).all(axis=1) & (np.linalg.norm(xyz, axis=1) > 0.1)
+    return xyz[valid].astype(np.float32), t_per_pt[valid]
+
+
+# ============================================================
+# Extrinsic loading (LiDAR-IMU, from airy_real_ext.yaml-style file)
+# ============================================================
+@dataclass
+class Extrinsic:
+    R_lidar_imu: np.ndarray  # 3x3, 把向量从 LiDAR 系转到 IMU 系: v_I = R * v_L
+    t_lidar_imu: np.ndarray  # 3
+    """
+    YAML 字段 mapping.extrinsic_T / extrinsic_R 在 fastlio 里语义是 "IMU 系下 LiDAR 原点
+    的位置 / LiDAR 系到 IMU 系的旋转". 见 IMU_Processing.hpp 的 set_extrinsic.
+    """
+
+    @staticmethod
+    def from_yaml(p: Path) -> "Extrinsic":
+        with open(p) as fp:
+            d = yaml.safe_load(fp)
+        # 兼容 fastlio yaml: /**:\n  ros__parameters:\n    mapping:\n      ...
+        mp = d.get("/**", {}).get("ros__parameters", {}).get("mapping", {})
+        if not mp:
+            raise RuntimeError(f"{p}: no /**.ros__parameters.mapping section")
+        R = np.array(mp["extrinsic_R"], dtype=np.float64).reshape(3, 3)
+        T = np.array(mp["extrinsic_T"], dtype=np.float64).reshape(3)
+        return Extrinsic(R_lidar_imu=R, t_lidar_imu=T)
+
+
+# ============================================================
+# IMU gravity estimation (-> R_gravity to align LiDAR z with world up)
+# ============================================================
+def estimate_gravity_in_lidar(imu_msgs, extrinsic: Extrinsic, gyro_thresh: float = 0.05):
+    """
+    输入 IMU 样本 (低运动段筛 ||gyro|| < gyro_thresh rad/s), 平均 acc -> g_imu (IMU 系下重力).
+    转到 LiDAR 系: g_lidar = R_lidar_imu^T @ g_imu  (因为 R 是 lidar->imu).
+
+    返回:
+      g_lidar (3,), unit vector (向下方向)
+      n_used (int): 用了几个样本
+    """
+    if not imu_msgs:
+        raise RuntimeError("no IMU samples in window")
+    accs = np.stack([m[1] for m in imu_msgs])   # (N, 3) m/s^2 in IMU frame
+    gyros = np.stack([m[2] for m in imu_msgs])  # (N, 3) rad/s
+    gyro_norm = np.linalg.norm(gyros, axis=1)
+    mask = gyro_norm < gyro_thresh
+    if mask.sum() < max(5, len(imu_msgs) // 4):
+        # 退化: 大部分时间都在动. 用全部样本平均 (会有偏差, 用户应在 bag 开头静止)
+        mask = np.ones(len(imu_msgs), dtype=bool)
+
+    g_imu = -accs[mask].mean(axis=0)   # acc 读到的是 -g (重力反向), 翻号得 g
+    # 兼容两种单位:
+    #   - 标准 ROS sensor_msgs/Imu: m/s^2, ||g|| ~ 9.81
+    #   - rslidar_sdk Airy IMU: g (gravitational units), ||g|| ~ 1.0
+    # 算法只用 unit vector 的方向, 所以单位无所谓; 但偏差太大说明 bag 开头在剧烈运动.
+    g_norm = np.linalg.norm(g_imu)
+    if not (0.5 < g_norm < 1.5 or 8.0 < g_norm < 12.0):
+        print(f"[warn] |g| in IMU frame = {g_norm:.4f} (expected ~1.0 g or ~9.81 m/s^2); "
+              f"bag 开头可能不静止 / IMU 装反", file=sys.stderr)
+    else:
+        unit_hint = "g-units" if g_norm < 2.0 else "m/s^2"
+        print(f"[gravity] |g_in_imu| = {g_norm:.4f} ({unit_hint})")
+    # 转到 LiDAR 系
+    g_lidar = extrinsic.R_lidar_imu.T @ g_imu
+    return g_lidar / np.linalg.norm(g_lidar), int(mask.sum())
+
+
+def rotation_from_two_vectors(v_from: np.ndarray, v_to: np.ndarray) -> np.ndarray:
+    """Rodrigues: 求 R, 使 R @ v_from = v_to. v_from, v_to 应为单位向量."""
+    v_from = v_from / np.linalg.norm(v_from)
+    v_to = v_to / np.linalg.norm(v_to)
+    cos_a = np.clip(np.dot(v_from, v_to), -1.0, 1.0)
+    if cos_a > 1 - 1e-9:
+        return np.eye(3)
+    if cos_a < -1 + 1e-9:
+        # 180°: 找个跟 v_from 不平行的轴
+        axis = np.cross(v_from, np.array([1.0, 0.0, 0.0]))
+        if np.linalg.norm(axis) < 1e-6:
+            axis = np.cross(v_from, np.array([0.0, 1.0, 0.0]))
+        axis /= np.linalg.norm(axis)
+        K = np.array([[0, -axis[2], axis[1]], [axis[2], 0, -axis[0]], [-axis[1], axis[0], 0]])
+        return np.eye(3) + 2 * K @ K
+    axis = np.cross(v_from, v_to)
+    sin_a = np.linalg.norm(axis)
+    axis /= sin_a
+    K = np.array([[0, -axis[2], axis[1]], [axis[2], 0, -axis[0]], [-axis[1], axis[0], 0]])
+    return np.eye(3) + sin_a * K + (1 - cos_a) * (K @ K)
+
+
+def gravity_align_rotation(g_lidar_unit: np.ndarray) -> np.ndarray:
+    """
+    返回 R_gl 使得: 点 p 在 gravity-aligned 系下 = R_gl @ p_in_lidar.
+    要求: R_gl @ g_lidar = (0, 0, -1)  (重力指向 -z, 即 +z 向上).
+    """
+    return rotation_from_two_vectors(g_lidar_unit, np.array([0.0, 0.0, -1.0]))
+
+
+# ============================================================
+# Open3D registration: FPFH + RANSAC + GICP
+# ============================================================
+def _yaw_rotation(theta_rad: float) -> np.ndarray:
+    c, s = math.cos(theta_rad), math.sin(theta_rad)
+    return np.array([[c, -s, 0], [s, c, 0], [0, 0, 1]], dtype=np.float64)
+
+
+def register_yaw_grid_then_refine(
+        source_xyz: np.ndarray, target_xyz: np.ndarray,
+        voxel: float = 0.3,
+        yaw_step_deg: float = 10.0,
+        coarse_voxel: float = None,
+        gicp_iter_coarse: int = 30,
+        gicp_iter_fine: int = 120):
+    """
+    4-DOF 全局对齐: 假定 source 和 target 都已 gravity-aligned (+z = up).
+    在 [0, 360) 范围内以 yaw_step_deg 步长扫 yaw, 每个 candidate:
+       1. 用 yaw 旋转 source, 平移到 (target center - rotated source center)
+       2. 在 coarse_voxel 上 GICP 评分
+    取 fitness 最高的, 进 fine voxel GICP 精修.
+    确定性 + 利用 gravity prior, 比 RANSAC+FPFH 在缺乏明显几何特征的场景更稳.
+    """
+    import open3d as o3d
+    if coarse_voxel is None:
+        coarse_voxel = voxel * 2.0
+
+    src = o3d.geometry.PointCloud()
+    src.points = o3d.utility.Vector3dVector(source_xyz.astype(np.float64))
+    tgt = o3d.geometry.PointCloud()
+    tgt.points = o3d.utility.Vector3dVector(target_xyz.astype(np.float64))
+
+    src_coarse = src.voxel_down_sample(coarse_voxel)
+    tgt_coarse = tgt.voxel_down_sample(coarse_voxel)
+    src_coarse.estimate_normals(o3d.geometry.KDTreeSearchParamHybrid(radius=coarse_voxel * 2, max_nn=30))
+    tgt_coarse.estimate_normals(o3d.geometry.KDTreeSearchParamHybrid(radius=coarse_voxel * 2, max_nn=30))
+
+    src_arr = np.asarray(src_coarse.points)
+    tgt_arr = np.asarray(tgt_coarse.points)
+    src_mean = src_arr.mean(axis=0)
+    tgt_mean = tgt_arr.mean(axis=0)
+
+    yaws = np.arange(0.0, 360.0, yaw_step_deg)
+    best = None
+    t0 = time.time()
+    for yaw_deg in yaws:
+        yaw_rad = math.radians(yaw_deg)
+        Rz = _yaw_rotation(yaw_rad)
+        # 用 mean alignment 给一个 reasonable translation init
+        t_init = tgt_mean - Rz @ src_mean
+        T_init = np.eye(4)
+        T_init[:3, :3] = Rz
+        T_init[:3, 3] = t_init
+
+        try:
+            r = o3d.pipelines.registration.registration_generalized_icp(
+                src_coarse, tgt_coarse, max_correspondence_distance=coarse_voxel * 2.0,
+                init=T_init,
+                criteria=o3d.pipelines.registration.ICPConvergenceCriteria(max_iteration=gicp_iter_coarse),
+            )
+        except Exception:
+            continue
+        if best is None or r.fitness > best["fitness"]:
+            best = {"T": np.asarray(r.transformation), "fitness": r.fitness,
+                    "rmse": r.inlier_rmse, "yaw_deg": yaw_deg}
+    t_coarse = time.time() - t0
+    if best is None:
+        return None
+    print(f"[yaw grid] {len(yaws)} candidates @ voxel={coarse_voxel:.2f}m  best yaw_init={best['yaw_deg']:.0f}°  "
+          f"fitness={best['fitness']:.4f} rmse={best['rmse']:.4f}  t={t_coarse:.2f}s")
+
+    # Fine refinement
+    src_fine = src.voxel_down_sample(voxel)
+    tgt_fine = tgt.voxel_down_sample(voxel)
+    src_fine.estimate_normals(o3d.geometry.KDTreeSearchParamHybrid(radius=voxel * 2, max_nn=30))
+    tgt_fine.estimate_normals(o3d.geometry.KDTreeSearchParamHybrid(radius=voxel * 2, max_nn=30))
+    t0 = time.time()
+    r = o3d.pipelines.registration.registration_generalized_icp(
+        src_fine, tgt_fine, max_correspondence_distance=voxel * 1.5,
+        init=best["T"],
+        criteria=o3d.pipelines.registration.ICPConvergenceCriteria(max_iteration=gicp_iter_fine),
+    )
+    t_fine = time.time() - t0
+    print(f"[gicp fine] voxel={voxel:.2f}m  src={len(src_fine.points)} tgt={len(tgt_fine.points)}  "
+          f"fitness={r.fitness:.4f} rmse={r.inlier_rmse:.4f}  t={t_fine:.2f}s")
+
+    return {
+        "T_target_source": np.asarray(r.transformation, dtype=np.float64),
+        "fitness": float(r.fitness),
+        "rmse": float(r.inlier_rmse),
+        "method": "yaw_grid+gicp",
+        "n_src_down": len(src_fine.points),
+        "n_tgt_down": len(tgt_fine.points),
+        "yaw_init_deg": float(best["yaw_deg"]),
+    }
+
+
+def register_global_then_refine(
+        source_xyz: np.ndarray, target_xyz: np.ndarray,
+        voxel: float = 0.3,
+        hint_T: np.ndarray = None,
+        hint_search_radius: float = 5.0,
+        ransac_voxel: float = None,
+        ransac_max_iter: int = 1000000,
+        ransac_confidence: float = 0.999,
+        rng_seed: int = 0):
+    """
+    返回 dict { 'T_target_source' (4x4), 'fitness', 'rmse', 'method', 'n_src_down', 'n_tgt_down', ... }.
+
+    分两段:
+      1. RANSAC+FPFH 在较大 voxel (ransac_voxel, 默认 = voxel*2) 上做全局粗对齐
+      2. GICP 在 voxel 上做精修
+
+    粗对齐用大 voxel 出于两个原因: (a) FPFH 描述子在大尺度上更稳, (b) RANSAC 搜索空间小.
+    精修用小 voxel 保几何精度.
+    """
+    import open3d as o3d
+    if ransac_voxel is None:
+        ransac_voxel = voxel * 2.0
+
+    src = o3d.geometry.PointCloud()
+    src.points = o3d.utility.Vector3dVector(source_xyz.astype(np.float64))
+    tgt = o3d.geometry.PointCloud()
+    tgt.points = o3d.utility.Vector3dVector(target_xyz.astype(np.float64))
+
+    # 精修用 voxel
+    src_fine = src.voxel_down_sample(voxel)
+    tgt_fine = tgt.voxel_down_sample(voxel)
+    src_fine.estimate_normals(o3d.geometry.KDTreeSearchParamHybrid(radius=voxel * 2, max_nn=30))
+    tgt_fine.estimate_normals(o3d.geometry.KDTreeSearchParamHybrid(radius=voxel * 2, max_nn=30))
+
+    if hint_T is None:
+        # 粗对齐用大 voxel
+        src_ds = src.voxel_down_sample(ransac_voxel)
+        tgt_ds = tgt.voxel_down_sample(ransac_voxel)
+        src_ds.estimate_normals(o3d.geometry.KDTreeSearchParamHybrid(radius=ransac_voxel * 2, max_nn=30))
+        tgt_ds.estimate_normals(o3d.geometry.KDTreeSearchParamHybrid(radius=ransac_voxel * 2, max_nn=30))
+
+        fpfh_radius = ransac_voxel * 5
+        src_fpfh = o3d.pipelines.registration.compute_fpfh_feature(
+            src_ds, o3d.geometry.KDTreeSearchParamHybrid(radius=fpfh_radius, max_nn=100))
+        tgt_fpfh = o3d.pipelines.registration.compute_fpfh_feature(
+            tgt_ds, o3d.geometry.KDTreeSearchParamHybrid(radius=fpfh_radius, max_nn=100))
+
+        t0 = time.time()
+        result = o3d.pipelines.registration.registration_ransac_based_on_feature_matching(
+            src_ds, tgt_ds, src_fpfh, tgt_fpfh, mutual_filter=True,
+            max_correspondence_distance=ransac_voxel * 1.5,
+            estimation_method=o3d.pipelines.registration.TransformationEstimationPointToPoint(False),
+            ransac_n=4,
+            checkers=[
+                o3d.pipelines.registration.CorrespondenceCheckerBasedOnEdgeLength(0.9),
+                o3d.pipelines.registration.CorrespondenceCheckerBasedOnDistance(ransac_voxel * 1.5),
+            ],
+            criteria=o3d.pipelines.registration.RANSACConvergenceCriteria(
+                ransac_max_iter, ransac_confidence),
+        )
+        init_T = result.transformation
+        ransac_t = time.time() - t0
+        print(f"[ransac] voxel={ransac_voxel:.2f}m  src={len(src_ds.points)} tgt={len(tgt_ds.points)} fpfh_r={fpfh_radius:.2f}m  "
+              f"fitness={result.fitness:.4f} rmse={result.inlier_rmse:.4f} t={ransac_t:.2f}s")
+        if result.fitness < 0.05:
+            print(f"[ransac] WARNING: low fitness, GICP refinement will likely fail. "
+                  f"Consider giving a --hint or increasing --ransac-voxel.")
+    else:
+        init_T = hint_T
+        print(f"[hint] using user-provided init, GICP only")
+
+    # GICP refine (在精细 voxel 上)
+    t0 = time.time()
+    result_icp = o3d.pipelines.registration.registration_generalized_icp(
+        src_fine, tgt_fine, max_correspondence_distance=voxel * 1.5,
+        init=init_T,
+        criteria=o3d.pipelines.registration.ICPConvergenceCriteria(max_iteration=120),
+    )
+    gicp_t = time.time() - t0
+    print(f"[gicp ] voxel={voxel:.2f}m  src={len(src_fine.points)} tgt={len(tgt_fine.points)}  "
+          f"fitness={result_icp.fitness:.4f} rmse={result_icp.inlier_rmse:.4f} t={gicp_t:.2f}s")
+
+    return {
+        "T_target_source": np.asarray(result_icp.transformation, dtype=np.float64),
+        "fitness": float(result_icp.fitness),
+        "rmse": float(result_icp.inlier_rmse),
+        "method": "ransac+gicp" if hint_T is None else "hint+gicp",
+        "n_src_down": len(src_fine.points),
+        "n_tgt_down": len(tgt_fine.points),
+    }
+
+
+# ============================================================
+# Helpers: 4x4 ↔ pos + quat (xyzw), yaml dump
+# ============================================================
+def matrix_to_pos_quat(T: np.ndarray) -> tuple:
+    """4x4 -> (pos[3], quat_xyzw[4])"""
+    R = T[:3, :3]
+    t = T[:3, 3]
+    # quat = R -> xyzw via scipy-free implementation
+    tr = R[0, 0] + R[1, 1] + R[2, 2]
+    if tr > 0:
+        S = 2.0 * math.sqrt(tr + 1.0)
+        qw = 0.25 * S
+        qx = (R[2, 1] - R[1, 2]) / S
+        qy = (R[0, 2] - R[2, 0]) / S
+        qz = (R[1, 0] - R[0, 1]) / S
+    elif R[0, 0] > R[1, 1] and R[0, 0] > R[2, 2]:
+        S = 2.0 * math.sqrt(1.0 + R[0, 0] - R[1, 1] - R[2, 2])
+        qw = (R[2, 1] - R[1, 2]) / S
+        qx = 0.25 * S
+        qy = (R[0, 1] + R[1, 0]) / S
+        qz = (R[0, 2] + R[2, 0]) / S
+    elif R[1, 1] > R[2, 2]:
+        S = 2.0 * math.sqrt(1.0 + R[1, 1] - R[0, 0] - R[2, 2])
+        qw = (R[0, 2] - R[2, 0]) / S
+        qx = (R[0, 1] + R[1, 0]) / S
+        qy = 0.25 * S
+        qz = (R[1, 2] + R[2, 1]) / S
+    else:
+        S = 2.0 * math.sqrt(1.0 + R[2, 2] - R[0, 0] - R[1, 1])
+        qw = (R[1, 0] - R[0, 1]) / S
+        qx = (R[0, 2] + R[2, 0]) / S
+        qy = (R[1, 2] + R[2, 1]) / S
+        qz = 0.25 * S
+    return t.copy(), np.array([qx, qy, qz, qw])
+
+
+def quat_xyzw_to_matrix(q: np.ndarray) -> np.ndarray:
+    qx, qy, qz, qw = q
+    n = qx*qx + qy*qy + qz*qz + qw*qw
+    if n < 1e-12:
+        return np.eye(3)
+    s = 2.0 / n
+    return np.array([
+        [1 - s*(qy*qy + qz*qz), s*(qx*qy - qz*qw),   s*(qx*qz + qy*qw)],
+        [s*(qx*qy + qz*qw),     1 - s*(qx*qx + qz*qz), s*(qy*qz - qx*qw)],
+        [s*(qx*qz - qy*qw),     s*(qy*qz + qx*qw),   1 - s*(qx*qx + qy*qy)],
+    ])
+
+
+# ============================================================
+# Main pipeline
+# ============================================================
+def main():
+    ap = argparse.ArgumentParser(description="Compute init pose for bag2 in bag1 prior map frame")
+    ap.add_argument("--bag", type=Path, required=True, help="rosbag2 directory (mcap/sqlite3)")
+    ap.add_argument("--prior", type=Path, required=True, help="prior map PCD (bag1 gravity-aligned recommended)")
+    ap.add_argument("--extrinsic-yaml", type=Path, required=True, help="airy_real_ext.yaml style file for LiDAR-IMU R/T")
+    ap.add_argument("--seconds", type=float, default=2.0, help="how many sec of bag head to use for init")
+    ap.add_argument("--voxel", type=float, default=0.3, help="voxel size for downsample + FPFH radius scaling")
+    ap.add_argument("--lidar-topic", default="/rslidar_points")
+    ap.add_argument("--imu-topic", default="/rslidar_imu_data")
+    ap.add_argument("--hint", default="",
+                    help="optional initial guess as x,y,z,qx,qy,qz,qw (语义: IMU 在 prior frame 的 pose). 给了 hint 走 GICP only")
+    ap.add_argument("--method", choices=["yaw_grid", "ransac"], default="yaw_grid",
+                    help="global init method when no hint: yaw_grid (4DOF, deterministic, default) or ransac (6DOF FPFH+RANSAC)")
+    ap.add_argument("--yaw-step-deg", type=float, default=10.0,
+                    help="yaw grid step (deg). 10° = 36 candidates")
+    ap.add_argument("--no-gravity", action="store_true", help="skip IMU gravity alignment (yaw_grid 必须有 gravity, 不能跟 --no-gravity 一起用)")
+    ap.add_argument("--out", type=Path, default=None, help="output yaml path (default: print only)")
+    ap.add_argument("--push-to-fastlio", action="store_true",
+                    help="after computing, call ROS2 service /set_init_pose to inject into fastlio_mapping")
+    ap.add_argument("--debug-dump", type=Path, default=None,
+                    help="dir to dump source/target downsampled PCDs + transformed result for inspection")
+    args = ap.parse_args()
+
+    print(f"=== init_pose_algo ===")
+    print(f"bag           : {args.bag}")
+    print(f"prior         : {args.prior}")
+    print(f"extrinsic_yaml: {args.extrinsic_yaml}")
+    print(f"seconds head  : {args.seconds}")
+    print(f"voxel         : {args.voxel}")
+
+    ext = Extrinsic.from_yaml(args.extrinsic_yaml)
+    print(f"R_lidar_imu det = {np.linalg.det(ext.R_lidar_imu):+.4f} (expect ±1)")
+
+    # 1. read bag head
+    t0 = time.time()
+    lidar_msgs, imu_msgs = read_bag_first_n_seconds(
+        args.bag, args.seconds, args.lidar_topic, args.imu_topic)
+    print(f"[bag] {len(lidar_msgs)} lidar / {len(imu_msgs)} imu msgs in first {args.seconds}s "
+          f"(read {time.time()-t0:.2f}s)")
+    if not lidar_msgs:
+        print("ERROR: no LiDAR frames", file=sys.stderr)
+        sys.exit(1)
+
+    # 2. IMU gravity
+    if args.no_gravity:
+        g_lidar = np.array([0.0, 0.0, -1.0])
+        R_gravity = np.eye(3)
+        print("[gravity] disabled (--no-gravity)")
+    else:
+        g_lidar, n_used = estimate_gravity_in_lidar(imu_msgs, ext)
+        R_gravity = gravity_align_rotation(g_lidar)
+        tilt_deg = math.degrees(math.acos(np.clip(-g_lidar[2], -1.0, 1.0)))
+        print(f"[gravity] g_in_lidar = {g_lidar} (tilt vs LiDAR-z = {tilt_deg:.2f}°)"
+              f", used {n_used}/{len(imu_msgs)} low-motion IMU samples")
+
+    # 3. accumulate source cloud (gravity-aligned LiDAR frame)
+    all_xyz = np.concatenate([m[1] for m in lidar_msgs], axis=0)
+    print(f"[accum] {len(all_xyz)} raw points from {len(lidar_msgs)} frames")
+    src_gravity_aligned = (R_gravity @ all_xyz.T).T.astype(np.float32)
+
+    # 4. load prior
+    t0 = time.time()
+    import open3d as o3d
+    prior_pcd = o3d.io.read_point_cloud(str(args.prior))
+    prior_xyz = np.asarray(prior_pcd.points, dtype=np.float32)
+    print(f"[prior] {len(prior_xyz)} points loaded ({time.time()-t0:.2f}s)")
+
+    # ---- IMU<->LiDAR 变换 ----
+    # fastlio 约定: state.pos/rot 是 IMU 在 world(prior_map) 的 pose.
+    # 算法内部用 LiDAR 点云配准, 得 T_priormap_lidar, 最后要转 IMU pose 推给 /set_init_pose.
+    # 关系 (见 laserMapping.cpp pointBodyToWorld):
+    #   p_world = R_imu_world @ (R_L_I @ p_lidar + t_L_I) + t_imu_world
+    # 其中 R_L_I = extrinsic_R, t_L_I = extrinsic_T (LiDAR -> IMU). 推:
+    #   T_priormap_imu = T_priormap_lidar @ inv([R_L_I | t_L_I])
+    T_imu_lidar = np.eye(4)
+    T_imu_lidar[:3, :3] = ext.R_lidar_imu
+    T_imu_lidar[:3, 3]  = ext.t_lidar_imu
+
+    # 5. registration
+    # hint 输入语义: IMU 在 prior frame 的 pose (与 service 接口一致).
+    # 内部 registration 是 LiDAR 配准, hint 要转回 LiDAR-pose 形式, 且要在 gravity-aligned 系下表达.
+    hint_T_for_reg = None
+    if args.hint:
+        parts = [float(x) for x in args.hint.split(",")]
+        if len(parts) != 7:
+            print("ERROR: --hint must be x,y,z,qx,qy,qz,qw (语义: IMU pose in prior frame)", file=sys.stderr)
+            sys.exit(2)
+        T_hint_imu = np.eye(4)
+        T_hint_imu[:3, 3] = parts[:3]
+        T_hint_imu[:3, :3] = quat_xyzw_to_matrix(np.array(parts[3:]))
+        # T_priormap_imu  -> T_priormap_lidar  -> T_priormap_(gravity_aligned_lidar)
+        T_hint_lidar = T_hint_imu @ T_imu_lidar
+        T_ga_inv = np.eye(4); T_ga_inv[:3, :3] = R_gravity.T
+        hint_T_for_reg = T_hint_lidar @ T_ga_inv
+
+    if hint_T_for_reg is not None:
+        result = register_global_then_refine(src_gravity_aligned, prior_xyz,
+                                             voxel=args.voxel, hint_T=hint_T_for_reg)
+    elif args.method == "yaw_grid":
+        if args.no_gravity:
+            print("ERROR: --method=yaw_grid requires gravity alignment, drop --no-gravity", file=sys.stderr)
+            sys.exit(2)
+        result = register_yaw_grid_then_refine(src_gravity_aligned, prior_xyz,
+                                               voxel=args.voxel,
+                                               yaw_step_deg=args.yaw_step_deg)
+        if result is None:
+            print("ERROR: yaw_grid registration failed (no candidates converged)", file=sys.stderr)
+            sys.exit(3)
+    else:  # ransac
+        result = register_global_then_refine(src_gravity_aligned, prior_xyz,
+                                             voxel=args.voxel)
+
+    # 6. Compose: T_priormap_lidar = T_priormap_(gravity_aligned_lidar) @ T_(gravity_aligned_lidar)_lidar
+    #    R_gravity 已经把 lidar 系转成 gravity-aligned 系, 所以从 lidar 系出发要先套 R_gravity
+    T_ga_from_lidar = np.eye(4)
+    T_ga_from_lidar[:3, :3] = R_gravity
+    T_priormap_lidar = result["T_target_source"] @ T_ga_from_lidar
+
+    # 7. LiDAR pose -> IMU pose (service / IKF 用的语义)
+    T_final = T_priormap_lidar @ np.linalg.inv(T_imu_lidar)
+
+    pos, quat = matrix_to_pos_quat(T_final)
+    rpy = _rotmat_to_rpy(T_final[:3, :3])
+    print(f"\n=== RESULT ===")
+    print(f"method   : {result['method']}")
+    print(f"fitness  : {result['fitness']:.4f}")
+    print(f"rmse     : {result['rmse']:.4f}  m")
+    print(f"src down : {result['n_src_down']} pts")
+    print(f"tgt down : {result['n_tgt_down']} pts")
+    print(f"pos (xyz)            : [{pos[0]:+.4f}, {pos[1]:+.4f}, {pos[2]:+.4f}]")
+    print(f"quat (xyzw)          : [{quat[0]:+.6f}, {quat[1]:+.6f}, {quat[2]:+.6f}, {quat[3]:+.6f}]")
+    print(f"rpy deg (zyx convent): roll={math.degrees(rpy[0]):+.2f}  pitch={math.degrees(rpy[1]):+.2f}  yaw={math.degrees(rpy[2]):+.2f}")
+
+    # 7. Output yaml
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        with open(args.out, "w") as fp:
+            yaml.safe_dump({
+                "method": result["method"],
+                "fitness": result["fitness"],
+                "rmse": result["rmse"],
+                "init_pos_xyz": pos.tolist(),
+                "init_rot_quat": quat.tolist(),
+                "T_4x4": T_final.tolist(),
+                "rpy_deg": [math.degrees(r) for r in rpy],
+                "voxel": args.voxel,
+                "seconds": args.seconds,
+            }, fp)
+        print(f"wrote {args.out}")
+
+    # 8. Optional debug dumps
+    if args.debug_dump:
+        args.debug_dump.mkdir(parents=True, exist_ok=True)
+        # source in prior frame: 用 LiDAR-pose 变换 (T_priormap_lidar), 不是 IMU-pose
+        src_xform = (T_priormap_lidar @ np.hstack([all_xyz, np.ones((len(all_xyz), 1))]).T).T[:, :3]
+        _save_pcd(args.debug_dump / "source_raw.pcd", all_xyz)
+        _save_pcd(args.debug_dump / "source_in_prior.pcd", src_xform)
+        # downsampled too
+        _save_pcd(args.debug_dump / "source_ds.pcd", np.asarray(o3d.geometry.PointCloud(
+            o3d.utility.Vector3dVector(src_gravity_aligned.astype(np.float64))).voxel_down_sample(args.voxel).points))
+        print(f"debug dumps in {args.debug_dump}")
+
+    # 9. Optional push to fastlio
+    if args.push_to_fastlio:
+        ok = _push_to_fastlio(pos, quat, result["fitness"])
+        if not ok:
+            sys.exit(3)
+
+
+def _rotmat_to_rpy(R: np.ndarray) -> tuple:
+    """Z-Y-X intrinsic (yaw, pitch, roll), return (roll, pitch, yaw) in rad."""
+    sy = math.sqrt(R[0, 0]**2 + R[1, 0]**2)
+    singular = sy < 1e-6
+    if not singular:
+        roll = math.atan2(R[2, 1], R[2, 2])
+        pitch = math.atan2(-R[2, 0], sy)
+        yaw = math.atan2(R[1, 0], R[0, 0])
+    else:
+        roll = math.atan2(-R[1, 2], R[1, 1])
+        pitch = math.atan2(-R[2, 0], sy)
+        yaw = 0.0
+    return roll, pitch, yaw
+
+
+def _save_pcd(path: Path, xyz: np.ndarray):
+    import open3d as o3d
+    p = o3d.geometry.PointCloud()
+    p.points = o3d.utility.Vector3dVector(np.asarray(xyz, dtype=np.float64))
+    o3d.io.write_point_cloud(str(path), p)
+
+
+def _push_to_fastlio(pos: np.ndarray, quat: np.ndarray, score: float) -> bool:
+    """调 ROS2 /set_init_pose service. 仅 --push-to-fastlio 时用."""
+    import subprocess
+    req = (
+        '{pose: {position: {x: %.6f, y: %.6f, z: %.6f}, '
+        'orientation: {x: %.6f, y: %.6f, z: %.6f, w: %.6f}}, score: %.4f}'
+    ) % (pos[0], pos[1], pos[2], quat[0], quat[1], quat[2], quat[3], score)
+    cmd = ["ros2", "service", "call", "/set_init_pose", "fast_lio_sam/srv/SetInitPose", req]
+    print(f"[push] $ {' '.join(cmd[:4])} <req>")
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except FileNotFoundError:
+        print("ERROR: ros2 CLI not found. Source /opt/ros/humble/setup.bash first.", file=sys.stderr)
+        return False
+    print(r.stdout)
+    if r.returncode != 0 or "success=True" not in r.stdout:
+        print(f"[push] FAILED ({r.returncode}): {r.stderr}", file=sys.stderr)
+        return False
+    print("[push] /set_init_pose accepted, fastlio_mapping IKF updated")
+    return True
+
+
+if __name__ == "__main__":
+    main()

--- a/FAST_LIO_SAM/tools/init_pose/init_pose_service.py
+++ b/FAST_LIO_SAM/tools/init_pose/init_pose_service.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""
+init_pose_service.py — ROS2 节点, 提供 /relocalize 服务.
+
+行为:
+  - 启动时加载 prior map PCD (一次性)
+  - 订阅 /rslidar_points + /rslidar_imu_data, 维护 ~3s 滑窗 buffer
+  - service /relocalize 被调时:
+      1. 从 buffer 取最近 N 秒数据
+      2. 调用 init_pose_algo.compute_init_pose() (open3d FPFH+RANSAC+GICP + IMU gravity)
+      3. 若 push_to_fastlio == true, 调 /set_init_pose service 把 pose 注入 fastlio_mapping
+      4. 返回 PoseWithCovariance + fitness + rmse
+
+参数 (ros2 args):
+  --ros-args -p prior_map:=<pcd_path>
+             -p extrinsic_yaml:=<airy_real_ext.yaml>
+             -p window_seconds:=2.0
+             -p voxel:=0.3
+             -p lidar_topic:=/rslidar_points
+             -p imu_topic:=/rslidar_imu_data
+             -p gyro_threshold:=0.05
+
+参考: Day 2c 计划. 算法核心见 init_pose_algo.py.
+"""
+
+import math
+import sys
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from typing import Deque, Tuple
+
+import numpy as np
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, QoSReliabilityPolicy, QoSHistoryPolicy
+from sensor_msgs.msg import PointCloud2, Imu
+
+# init_pose_algo 在同目录, 直接同进程 import
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE))
+import init_pose_algo as algo  # noqa: E402
+
+# 用项目 srv
+from fast_lio_sam.srv import Relocalize, SetInitPose
+
+
+class InitPoseService(Node):
+    def __init__(self):
+        super().__init__("init_pose_service")
+
+        # ---- Parameters ----
+        self.declare_parameter("prior_map", "")
+        self.declare_parameter("extrinsic_yaml", "")
+        self.declare_parameter("window_seconds", 2.0)
+        self.declare_parameter("voxel", 0.3)
+        self.declare_parameter("lidar_topic", "/rslidar_points")
+        self.declare_parameter("imu_topic", "/rslidar_imu_data")
+        self.declare_parameter("gyro_threshold", 0.05)
+        self.declare_parameter("set_init_pose_service", "/set_init_pose")
+        self.declare_parameter("ransac_max_iter", 100000)
+
+        self.prior_map_path = self.get_parameter("prior_map").value
+        self.extrinsic_yaml = self.get_parameter("extrinsic_yaml").value
+        self.window_seconds = float(self.get_parameter("window_seconds").value)
+        self.voxel = float(self.get_parameter("voxel").value)
+        self.lidar_topic = self.get_parameter("lidar_topic").value
+        self.imu_topic = self.get_parameter("imu_topic").value
+        self.gyro_threshold = float(self.get_parameter("gyro_threshold").value)
+        self.set_pose_srv_name = self.get_parameter("set_init_pose_service").value
+        self.ransac_max_iter = int(self.get_parameter("ransac_max_iter").value)
+
+        if not self.prior_map_path or not Path(self.prior_map_path).exists():
+            self.get_logger().error(f"prior_map missing or not found: {self.prior_map_path!r}")
+            raise SystemExit(2)
+        if not self.extrinsic_yaml or not Path(self.extrinsic_yaml).exists():
+            self.get_logger().error(f"extrinsic_yaml missing or not found: {self.extrinsic_yaml!r}")
+            raise SystemExit(2)
+
+        # ---- Load extrinsic ----
+        self.ext = algo.Extrinsic.from_yaml(Path(self.extrinsic_yaml))
+        self.get_logger().info(
+            f"extrinsic R det={np.linalg.det(self.ext.R_lidar_imu):+.4f}, t={self.ext.t_lidar_imu}")
+
+        # ---- Load prior map (in main thread, blocking) ----
+        t0 = time.time()
+        import open3d as o3d
+        self.prior_pcd = o3d.io.read_point_cloud(self.prior_map_path)
+        self.prior_xyz = np.asarray(self.prior_pcd.points, dtype=np.float32)
+        self.get_logger().info(
+            f"prior_map loaded: {len(self.prior_xyz)} pts from {self.prior_map_path} ({time.time()-t0:.2f}s)")
+
+        # ---- Buffers ----
+        self._lidar_lock = threading.Lock()
+        self._imu_lock = threading.Lock()
+        self._lidar_buf: Deque[Tuple[float, np.ndarray]] = deque()    # (ts_sec, xyz[N,3])
+        self._imu_buf: Deque[Tuple[float, np.ndarray, np.ndarray]] = deque()
+
+        # ---- Subscribers (BEST_EFFORT — driver typically RELIABLE pub, BE sub matches OK) ----
+        qos_be_keep_last_100 = QoSProfile(
+            reliability=QoSReliabilityPolicy.BEST_EFFORT,
+            history=QoSHistoryPolicy.KEEP_LAST, depth=100)
+        qos_be_keep_last_1000 = QoSProfile(
+            reliability=QoSReliabilityPolicy.BEST_EFFORT,
+            history=QoSHistoryPolicy.KEEP_LAST, depth=1000)
+
+        self.sub_lidar = self.create_subscription(
+            PointCloud2, self.lidar_topic, self._lidar_cb, qos_be_keep_last_100)
+        self.sub_imu = self.create_subscription(
+            Imu, self.imu_topic, self._imu_cb, qos_be_keep_last_1000)
+
+        # ---- Service: /relocalize ----
+        self.srv_relocalize = self.create_service(
+            Relocalize, "/relocalize", self._relocalize_cb)
+
+        # ---- Client: /set_init_pose ----
+        self.cli_set_pose = self.create_client(SetInitPose, self.set_pose_srv_name)
+
+        self.get_logger().info(
+            f"ready. window={self.window_seconds}s voxel={self.voxel}m  "
+            f"sub: {self.lidar_topic} {self.imu_topic}  "
+            f"srv: /relocalize  client: {self.set_pose_srv_name}")
+
+    # ---------------- subscriber callbacks ----------------
+    def _lidar_cb(self, msg: PointCloud2):
+        ts = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
+        try:
+            xyz, _ = algo._decode_pointcloud2(msg)
+        except Exception as e:
+            self.get_logger().warn(f"lidar decode failed: {e}")
+            return
+        with self._lidar_lock:
+            self._lidar_buf.append((ts, xyz))
+            # 老数据踢出 (保留 window_seconds + 1s margin)
+            cutoff = ts - (self.window_seconds + 1.0)
+            while self._lidar_buf and self._lidar_buf[0][0] < cutoff:
+                self._lidar_buf.popleft()
+
+    def _imu_cb(self, msg: Imu):
+        ts = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
+        acc = np.array([msg.linear_acceleration.x,
+                        msg.linear_acceleration.y,
+                        msg.linear_acceleration.z], dtype=np.float64)
+        gyro = np.array([msg.angular_velocity.x,
+                         msg.angular_velocity.y,
+                         msg.angular_velocity.z], dtype=np.float64)
+        with self._imu_lock:
+            self._imu_buf.append((ts, acc, gyro))
+            cutoff = ts - (self.window_seconds + 1.0)
+            while self._imu_buf and self._imu_buf[0][0] < cutoff:
+                self._imu_buf.popleft()
+
+    # ---------------- service callback ----------------
+    def _relocalize_cb(self, req: Relocalize.Request, res: Relocalize.Response):
+        t0 = time.time()
+        self.get_logger().info(
+            f"/relocalize called: hint=({req.hint.position.x:+.3f},{req.hint.position.y:+.3f},{req.hint.position.z:+.3f}) "
+            f"search_radius={req.search_radius:.2f} use_imu_gravity={req.use_imu_gravity} push={req.push_to_fastlio}")
+
+        # 1. snapshot buffers (under lock)
+        with self._lidar_lock:
+            lidar_snap = list(self._lidar_buf)
+        with self._imu_lock:
+            imu_snap = list(self._imu_buf)
+
+        if not lidar_snap:
+            res.success = False
+            res.message = "no lidar in buffer (driver not publishing? or just started)"
+            self.get_logger().error(res.message)
+            return res
+        if req.use_imu_gravity and not imu_snap:
+            res.success = False
+            res.message = "no imu in buffer (use_imu_gravity=true requires IMU samples)"
+            self.get_logger().error(res.message)
+            return res
+
+        # 2. cut to window_seconds
+        t_latest = lidar_snap[-1][0]
+        t_start = t_latest - self.window_seconds
+        lidar_window = [(ts, xyz) for (ts, xyz) in lidar_snap if ts >= t_start]
+        imu_window = [(ts, a, g) for (ts, a, g) in imu_snap if ts >= t_start]
+        self.get_logger().info(
+            f"window: {len(lidar_window)} lidar + {len(imu_window)} imu over last {self.window_seconds:.2f}s")
+
+        # 3. gravity
+        if req.use_imu_gravity and imu_window:
+            # adapt to existing algo.estimate_gravity_in_lidar API which expects (ts, acc, gyro) tuples
+            try:
+                g_lidar, n_used = algo.estimate_gravity_in_lidar(imu_window, self.ext, self.gyro_threshold)
+            except Exception as e:
+                res.success = False
+                res.message = f"gravity estimation failed: {e}"
+                self.get_logger().error(res.message)
+                return res
+            R_gravity = algo.gravity_align_rotation(g_lidar)
+            tilt = math.degrees(math.acos(np.clip(-g_lidar[2], -1, 1)))
+            self.get_logger().info(
+                f"gravity tilt={tilt:.2f}°  ({n_used}/{len(imu_window)} low-motion samples)")
+        else:
+            R_gravity = np.eye(3)
+            self.get_logger().info("gravity skipped (use_imu_gravity=false or no imu)")
+
+        # 4. accumulate source cloud, gravity-align
+        all_xyz = np.concatenate([m[1] for m in lidar_window], axis=0)
+        src_ga = (R_gravity @ all_xyz.T).T.astype(np.float32)
+
+        # IMU<->LiDAR 变换. /relocalize 输入 hint 与 /set_init_pose 输出 pose 都是
+        # "IMU 在 prior frame 的 pose" 语义, 内部 registration 用 LiDAR 系, 需要转换.
+        T_imu_lidar = np.eye(4)
+        T_imu_lidar[:3, :3] = self.ext.R_lidar_imu
+        T_imu_lidar[:3, 3]  = self.ext.t_lidar_imu
+
+        # 5. parse hint (语义: IMU 在 prior frame 的 pose)
+        hint_T_for_reg = None
+        h = req.hint
+        if abs(h.position.x) + abs(h.position.y) + abs(h.position.z) > 1e-9 or \
+                abs(h.orientation.x) + abs(h.orientation.y) + abs(h.orientation.z) + abs(h.orientation.w - 1.0) > 1e-6:
+            T_hint_imu = np.eye(4)
+            T_hint_imu[:3, 3] = [h.position.x, h.position.y, h.position.z]
+            T_hint_imu[:3, :3] = algo.quat_xyzw_to_matrix(np.array([
+                h.orientation.x, h.orientation.y, h.orientation.z, h.orientation.w]))
+            # IMU pose -> LiDAR pose -> gravity-aligned LiDAR pose (registration 接受这个)
+            T_hint_lidar = T_hint_imu @ T_imu_lidar
+            T_ga_inv = np.eye(4); T_ga_inv[:3, :3] = R_gravity.T
+            hint_T_for_reg = T_hint_lidar @ T_ga_inv
+
+        # 6. registration
+        try:
+            r = algo.register_global_then_refine(
+                src_ga, self.prior_xyz,
+                voxel=self.voxel, hint_T=hint_T_for_reg,
+                ransac_max_iter=self.ransac_max_iter,
+            )
+        except Exception as e:
+            res.success = False
+            res.message = f"registration failed: {e}"
+            self.get_logger().error(res.message)
+            return res
+
+        # 7. compose final pose: T_priormap_lidar -> T_priormap_imu
+        T_ga_from_lidar = np.eye(4)
+        T_ga_from_lidar[:3, :3] = R_gravity
+        T_priormap_lidar = r["T_target_source"] @ T_ga_from_lidar
+        T_final = T_priormap_lidar @ np.linalg.inv(T_imu_lidar)
+
+        pos, quat = algo.matrix_to_pos_quat(T_final)
+
+        # 8. fill response
+        res.success = True
+        res.pose.pose.position.x = float(pos[0])
+        res.pose.pose.position.y = float(pos[1])
+        res.pose.pose.position.z = float(pos[2])
+        res.pose.pose.orientation.x = float(quat[0])
+        res.pose.pose.orientation.y = float(quat[1])
+        res.pose.pose.orientation.z = float(quat[2])
+        res.pose.pose.orientation.w = float(quat[3])
+        # 简单的 cov 估计: 用 rmse 作为 xyz σ, 用一个保守的角度 σ
+        sigma_xy = max(r["rmse"], 0.05)
+        sigma_z = max(r["rmse"], 0.05)
+        sigma_rpy = math.radians(2.0)  # 默认 ~2° 不确定性
+        cov = np.zeros(36)
+        cov[0] = sigma_xy ** 2
+        cov[7] = sigma_xy ** 2
+        cov[14] = sigma_z ** 2
+        cov[21] = sigma_rpy ** 2
+        cov[28] = sigma_rpy ** 2
+        cov[35] = sigma_rpy ** 2
+        res.pose.covariance = cov.tolist()
+
+        res.fitness = float(r["fitness"])
+        res.rmse = float(r["rmse"])
+        res.message = (
+            f"{r['method']} fitness={r['fitness']:.3f} rmse={r['rmse']:.3f}m "
+            f"src={r['n_src_down']} tgt={r['n_tgt_down']}  total_time={time.time()-t0:.2f}s")
+        self.get_logger().info(f"/relocalize done: {res.message}")
+        self.get_logger().info(
+            f"  pos=[{pos[0]:+.3f},{pos[1]:+.3f},{pos[2]:+.3f}] "
+            f"quat=[{quat[0]:+.4f},{quat[1]:+.4f},{quat[2]:+.4f},{quat[3]:+.4f}]")
+
+        # 9. optionally push to fastlio_mapping via /set_init_pose
+        if req.push_to_fastlio:
+            push_ok = self._push_to_fastlio(pos, quat, r["fitness"])
+            if not push_ok:
+                res.success = False
+                res.message += " (push_to_fastlio FAILED)"
+        return res
+
+    def _push_to_fastlio(self, pos, quat, score) -> bool:
+        if not self.cli_set_pose.wait_for_service(timeout_sec=3.0):
+            self.get_logger().error(f"{self.set_pose_srv_name} not available (fastlio_mapping not running?)")
+            return False
+        req = SetInitPose.Request()
+        req.pose.position.x = float(pos[0])
+        req.pose.position.y = float(pos[1])
+        req.pose.position.z = float(pos[2])
+        req.pose.orientation.x = float(quat[0])
+        req.pose.orientation.y = float(quat[1])
+        req.pose.orientation.z = float(quat[2])
+        req.pose.orientation.w = float(quat[3])
+        req.score = float(score)
+        fut = self.cli_set_pose.call_async(req)
+        # spin until done (we're inside a service cb but use a separate spin briefly)
+        rclpy.spin_until_future_complete(self, fut, timeout_sec=5.0)
+        if not fut.done() or fut.result() is None:
+            self.get_logger().error(f"{self.set_pose_srv_name} timed out")
+            return False
+        r = fut.result()
+        if not r.success:
+            self.get_logger().error(f"{self.set_pose_srv_name} returned failure: {r.message}")
+            return False
+        self.get_logger().info(f"{self.set_pose_srv_name}: {r.message}")
+        return True
+
+
+def main():
+    rclpy.init()
+    node = InitPoseService()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

把此前散落的内容收口为单一分支并入 main:
- 之前 workspace 实际编译的是非 git 的 `~/Codes/fast-lio-sam`,它是 z-up 修复线 + init_pose 线的临时合并、还带未提交改动。本 PR 把这些全部收进 git。
- 新增 `/mapping_control` ROS2 service,供外部控制建图(PAUSE/RESUME/STOP/STATUS)。
- workspace `src/FAST_LIO_SAM` 编译源已 symlink 切到 fls-meta(不再依赖 ~/Codes)。

## 包含的 commit (相对 origin/main 领先 5 个, 干净快进)

- `34873e7` fix: airy z-up / loop 重影 / 几公里漂飞 (laserMapping ICP+odom noise, IMU z-up rot init)
- `64ef8c3` feat: init_pose 重定位 (srv SetInitPose/Relocalize + tools/init_pose + config/airy_localization*)
- `4c83ba1` merge: 把 init_pose 并入 z-up 基线
- `1490e21` fix: 抢救 ~/Codes 未提交 PGO 健壮性 (IndeterminantLinearSystemException try/catch + 退出 saveMap)
- `796173c` feat: `/mapping_control` service (PAUSE/RESUME/STOP/STATUS)

## /mapping_control 接口

`srv/MappingControl.srv`: `command`(大小写不敏感: PAUSE/RESUME/STOP/STATUS) + STOP 用 `resolution`/`destination`。
响应: `success` / `state` / `keyframe_count` / `path_points` / `message`。
主循环 `mapping_active` 门控; 不支持运行中清空重建(重图靠重启节点)。

## Test plan

- [x] `colcon build fast_lio_sam` 通过 (Humble, Release)
- [x] `/mapping_control` dataless 冒烟: STATUS / pause / RESUME / 未知命令 均返回预期, 服务正常注册
- [ ] 实机/bag 验证 STOP 真数据落盘 + PAUSE→RESUME 时间间隔对 IEKF 的影响 (跟踪于 #34)

Closes #33