### PR TITLE
把 2D-mapping 流水线 (build_2d_map/footprint_filter) 并入 main

### DIFF
--- a/FAST_LIO_SAM/tools/README.md
+++ b/FAST_LIO_SAM/tools/README.md
@@ -1,0 +1,33 @@
+# tools/ — 离线后处理工具
+
+FAST-LIO-SAM 跑完 + `ros2 service call /save_map` 后, 这里的脚本把 SaveMap 输出
+(`GlobalMap.pcd` / `trajectory.pcd` / `transformations.pcd` + `pcd/`) 加工成可用产物。
+
+## 2D 占据栅格图 (nav2 / amcl) —— 从这里开始
+
+**一条命令: [`build_2d_map/build_2d_map.py`](build_2d_map/README.md)**
+
+```bash
+# 默认 (手持采集)
+python3 tools/build_2d_map/build_2d_map.py ~/Downloads/LOAM -o ~/maps/room
+# 机器狗 (雷达低 + 体型): 用 dog profile
+python3 tools/build_2d_map/build_2d_map.py <SaveMap目录> -o ~/maps/dog_room --profile dog
+# 加载
+ros2 run nav2_map_server map_server --ros-args -p yaml_filename:=~/maps/room.yaml
+```
+
+它内部串 3 步 (一般不用单独跑):
+
+| 步骤 | 脚本 | 作用 |
+|---|---|---|
+| 1 | [`align_floor/`](align_floor/README.md) | RANSAC 拟合地面 → 旋转使 z=0=真地面 (修手持重力倾斜). 只接受近竖直法向, 不会锁到墙. |
+| 2 | [`pcd_to_occgrid/`](pcd_to_occgrid/README.md) | z 切片 + 投影 + 沿轨迹 polar raycast 填 free + 可选 footprint 排除 + autocrop 裁空白边 |
+| (可选) | [`footprint_filter/`](footprint_filter/README.md) | per-scan 在传感器局部系按外参切除操作员/机身 (比 pcd_to_occgrid 的全局 `--footprint-radius` 更准) |
+
+> ⚠️ 不要用其它包里的 `generate_occupancy_map_from_pcd.py` 之类脚本生成 airy/dog 2D 图
+> —— 那类 full-map height-delta 启发式在带地面噪声的 LOAM 点云上几乎全判障碍, 不可用。
+
+## 其它
+
+- [`airy_extrinsic/`](airy_extrinsic/) — 从 RoboSense Airy DIFOP 解 IMU↔LiDAR 外参, 出 config / footprint_filter 用的 yaml
+- `init_pose/` — 定位初始位姿工具

--- a/FAST_LIO_SAM/tools/align_floor/align_floor.py
+++ b/FAST_LIO_SAM/tools/align_floor/align_floor.py
@@ -90,8 +90,14 @@ def fit_plane_ransac(
     n_iter: int = 500,
     inlier_thresh: float = 0.05,
     seed: int = 42,
+    min_normal_z: float = 0.7,
 ) -> tuple[np.ndarray, float, int]:
-    """RANSAC 拟合平面, 返回 (法向 n, d, 内点数). n 已归一化, 默认指向 +z."""
+    """RANSAC 拟合平面, 返回 (法向 n, d, 内点数). n 已归一化, 默认指向 +z.
+
+    min_normal_z: 只接受法向近竖直 (|n_z| >= 该值) 的平面. 防止在室内把竖直墙面
+    当地面 — "最低 20% z" 的地面候选带里, 长墙的底部点往往比地面点还多, 纯"最大
+    内点平面" RANSAC 会锁到墙 (法向水平), 再翻成 +z 得到 ~86° 的假地面, 把整张图
+    旋歪. 地面残留倾斜一般只有几度, 默认 0.7 (允许到 45°) 极安全且能干净拒绝墙."""
     rng = np.random.default_rng(seed)
     best_inl = 0
     best = None
@@ -103,6 +109,8 @@ def fit_plane_ransac(
         if nn < 1e-6:
             continue
         n /= nn
+        if abs(float(n[2])) < min_normal_z:
+            continue  # 不是近水平面 (地面), 跳过 — 拒绝墙/家具立面
         d = -n @ p1
         dist = np.abs(pts @ n + d)
         inl = (dist < inlier_thresh).sum()
@@ -110,7 +118,10 @@ def fit_plane_ransac(
             best_inl = inl
             best = (n.copy(), float(d))
     if best is None:
-        raise RuntimeError("RANSAC 找不到平面")
+        raise RuntimeError(
+            f"RANSAC 找不到近水平地面 (|n_z| >= {min_normal_z}). "
+            f"点云可能没 z-up, 或地面候选带里全是墙 — 试 --floor-z-range 手动缩小地面 z 区间."
+        )
     n, d = best
     if n[2] < 0:
         n, d = -n, -d

--- a/FAST_LIO_SAM/tools/build_2d_map/README.md
+++ b/FAST_LIO_SAM/tools/build_2d_map/README.md
@@ -1,0 +1,110 @@
+# build_2d_map — 一条命令做出 nav2 兼容 PGM/YAML
+
+把 FAST-LIO-SAM 的 SaveMap 输出转成 nav2 全局规划用的 2D 占据栅格，封装了：
+
+1. **align_floor** — RANSAC 拟合地面，旋转 + 平移让 z=0 = 真地面、z 轴 = 真重力
+2. **pcd_to_occgrid** — z 切片 + 投影 + 沿轨迹做 polar raycast 填 free space
+
+> 解决 issue #21.
+
+## 为什么要封装
+
+3 步分开跑非常容易踩坑：
+
+- **漏 align**：z=0 是 LIO init 位置（LiDAR 杆顶），切片 `[0.2, 1.5]` 切到空中，PGM 几乎全空
+- **顺序错**：raycast 用的轨迹和点云不在同一坐标系，free space 全错位
+- **路径乱**：中间产物到处放
+
+## 用法
+
+```bash
+# 最简: SaveMap 输出 ($HOME/Downloads/LOAM/) 转 nav2 map
+python3 build_2d_map.py ~/Downloads/LOAM/ -o ~/maps/airy_room
+
+# 然后:
+ros2 run nav2_map_server map_server --ros-args -p yaml_filename:=~/maps/airy_room.yaml
+```
+
+## 选项
+
+```bash
+build_2d_map.py SAVEMAP_DIR -o OUT_PREFIX [选项]
+
+# 跳过 gravity-align (点云已经对齐时)
+--no-align
+
+# 跳过 raycast (只标 occupied + 地面切片 free)
+--no-raycast
+
+# 切片 (默认地面以上 0.2-1.5m, 适合人/狗高度)
+--z-min 0.10 --z-max 1.50
+
+# 自定义分辨率
+--resolution 0.05
+
+# 调 raycast 距离 (默认 30m)
+--raycast-range 30.0
+
+# 保留中间产物 (debug 用), 输出到 OUT_PREFIX.aligned/
+--keep-intermediate
+
+# 手动指定地面 z (RANSAC 自动失败时的 fallback)
+--floor-z-range -3.0 -2.0
+```
+
+## 输出
+
+```
+~/maps/airy_room.pgm           # nav2 standard PGM (8bit gray)
+~/maps/airy_room.yaml          # nav2 map_server YAML
+~/maps/airy_room.summary.txt   # 跑了什么, 切片范围, raycast 状态
+
+# --keep-intermediate 时还有:
+~/maps/airy_room.aligned/
+    GlobalMap.pcd              # gravity-aligned 点云
+    trajectory.pcd             # gravity-aligned 关键帧
+    transformations.pcd        # gravity-aligned 6D 位姿
+    step2_align.log            # align_floor 日志 + RANSAC 结果
+    step3_occgrid.log          # pcd_to_occgrid 日志 + 切片统计
+```
+
+## 工作流图
+
+```
+LIO 跑完 (mapping_bag.launch.py / mapping_airy.launch.py)
+    ↓
+SaveMap service 触发 (launch shutdown 时自动, 见 commit b5f4c88)
+    ↓
+$HOME/Downloads/LOAM/{GlobalMap,trajectory,transformations}.pcd
+    ↓ build_2d_map.py
+$out_prefix.pgm + $out_prefix.yaml
+    ↓ ros2 run nav2_map_server map_server
+nav2 + amcl 全局规划
+```
+
+## 常见问题
+
+**Q: PGM 空白 / 几乎全 unknown**
+
+A: 可能没 align, 或者切片范围不对.
+- 先看 `summary.txt` 的 `align: ON/OFF`. 应该是 ON
+- 看中间日志 `step2_align.log` 里的 `tilt vs +z` 行, 如果 > 5°, 数据本身有问题
+- 看 `step3_occgrid.log` 里 `z: [...]` 范围, 如果切片把整个范围切空了, 调 `--z-min`/`--z-max`
+
+**Q: 走廊远端是 unknown 不是 free**
+
+A: raycast 只对**击中 occupied 的射线**填 free. 远端没墙的方向（开阔地）保持 unknown 是有意为之 — 没观测就不假设.
+- 如果场景就是没墙, 用 `--no-raycast` + 调 `--floor-z` 让地面观测当 free
+- 或者单独跑 OctoMap 处理开阔区
+
+**Q: 跑很慢 / 卡住**
+
+A: raycast 是 pure python (issue #16 跟踪性能). 大场景可以:
+- 调小 `--raycast-range` (默认 30m → 试 15m)
+- `--no-raycast` 跳过这步, 牺牲 free 覆盖率换速度
+
+## 限制
+
+- 只支持单层场景. 多层楼要先按 z 拆点云 (例如 `pdal pipeline` filter), 分别跑
+- 假设场景有大块平地. 纯户外起伏地形会让 RANSAC 拟合错, 用 `--floor-z-range` 手动指定 (issue #17)
+- 真 3D raycast 在 issue #20 跟踪

--- a/FAST_LIO_SAM/tools/build_2d_map/build_2d_map.py
+++ b/FAST_LIO_SAM/tools/build_2d_map/build_2d_map.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""
+build_2d_map — 从 FAST-LIO-SAM 的 SaveMap 输出一条命令做出 nav2 兼容 PGM/YAML.
+
+串了 3 步:
+  1. SaveMap 结果检查    (确认 GlobalMap.pcd / trajectory.pcd 存在)
+  2. align_floor         (RANSAC 拟合地面, 旋转+平移使 z=0=地面, z 轴=真重力)
+  3. pcd_to_occgrid      (z 切片 + 投影 + 沿轨迹 polar raycast 填 free space)
+
+为什么需要这层封装:
+  3 步分开跑容易出错.
+    - 漏 align: z=0 是 LIO init 位置, 切 [0.2, 1.5] 切到空中, PGM 空白
+    - 顺序错: raycast 用的轨迹和点云不在同一坐标系, free 全错
+    - 路径乱: 中间产物到处放
+  这个 wrapper 把默认值调好, 一条命令出 PGM, 中间产物可选保留供 debug.
+
+依赖: 已安装 align_floor.py 和 pcd_to_occgrid.py (同 repo, 同级目录).
+
+用法:
+    # 最简
+    build_2d_map.py ~/Downloads/LOAM/ -o ~/maps/airy_room
+    # 开 RViz / nav2 用
+    ros2 run nav2_map_server map_server --ros-args -p yaml_filename:=~/maps/airy_room.yaml
+
+    # 跳过 align (点云已经对齐了)
+    build_2d_map.py ~/Downloads/LOAM/ -o ~/maps/airy_room --no-align
+
+    # 保留中间产物
+    build_2d_map.py ~/Downloads/LOAM/ -o ~/maps/airy_room --keep-intermediate
+
+    # 调切片 (机器狗很矮)
+    build_2d_map.py ~/Downloads/LOAM/ -o ~/maps/dog_room --z-min 0.10 --z-max 0.40
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+from pathlib import Path
+
+
+# ============================================================
+HERE = Path(__file__).resolve().parent
+ALIGN_FLOOR  = HERE.parent / "align_floor" / "align_floor.py"
+PCD_TO_OCC   = HERE.parent / "pcd_to_occgrid" / "pcd_to_occgrid.py"
+FOOTPRINT_FILTER = HERE.parent / "footprint_filter" / "footprint_filter.py"
+
+
+def run_step(name: str, cmd: list[str], log_path: Path) -> tuple[int, str, str]:
+    """跑一步, 返回 (returncode, stdout, stderr); 进度输出实时打到屏幕."""
+    print(f"[{name}] 执行: {' '.join(str(c) for c in cmd)}")
+    t0 = time.time()
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    dur = time.time() - t0
+    log_path.write_text(
+        f"# {name} ({dur:.1f}s, exit={proc.returncode})\n"
+        f"# cmd: {' '.join(cmd)}\n\n"
+        f"=== stdout ===\n{proc.stdout}\n"
+        f"=== stderr ===\n{proc.stderr}\n"
+    )
+    if proc.returncode != 0:
+        print(f"[{name}] ❌ 失败 (exit={proc.returncode}, {dur:.1f}s)")
+        sys.stderr.write(proc.stdout)
+        sys.stderr.write(proc.stderr)
+    else:
+        print(f"[{name}] ✅ 完成 ({dur:.1f}s)")
+        # 把关键统计行抽出来
+        for line in proc.stdout.splitlines():
+            low = line.lower()
+            if any(k in low for k in ["tilt", "inliers", "raycast", "尺寸", "occupied", "free", "[ok]"]):
+                print(f"[{name}]   {line}")
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def find_pcd(loam_dir: Path, name: str) -> Path:
+    """SaveMap 默认放 $HOME/Downloads/LOAM/, 找 GlobalMap.pcd 等."""
+    p = loam_dir / name
+    if p.is_file():
+        return p
+    raise FileNotFoundError(
+        f"未找到 {name} 在 {loam_dir}. SaveMap service 是否调用过? 查 launch.log:\n"
+        f"  ros2 service call /save_map fast_lio_sam/srv/SaveMap '{{resolution: 0.0, destination: \"\"}}'"
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("loam_dir", type=Path,
+                    help="SaveMap service 输出目录 (含 GlobalMap.pcd / trajectory.pcd)")
+    ap.add_argument("-o", "--output", type=Path, required=True,
+                    help="输出文件前缀, 例: ~/maps/airy_room (会得到 .pgm + .yaml)")
+
+    g_align = ap.add_argument_group("step 2: align_floor")
+    g_align.add_argument("--no-align", action="store_true",
+                         help="跳过 gravity-align (点云已对齐时用)")
+    g_align.add_argument("--floor-z-range", type=float, nargs=2, default=None,
+                         metavar=("Z_MIN", "Z_MAX"),
+                         help="手动指定地面 z 区间 (默认: align_floor 自动)")
+
+    g_occ = ap.add_argument_group("step 3: pcd_to_occgrid")
+    g_occ.add_argument("--profile", choices=["handheld", "dog", "vehicle", "generic"],
+                       default="handheld",
+                       help="采集场景预设 (默认 handheld). 决定 z 切片 + footprint 半径:\n"
+                            "  handheld : z=[0.2, 1.5]  footprint=0.3m  (人手持采集)\n"
+                            "  dog      : z=[0.1, 0.5]  footprint=0.4m  (机器狗高度低 + 体型)\n"
+                            "  vehicle  : z=[0.3, 2.0]  footprint=1.0m  (车上 LiDAR)\n"
+                            "  generic  : z=[0.1, 1.5]  footprint=0    (不知道用啥, 不排除)\n"
+                            "可以单独覆盖个别参数 (--z-min / --footprint-radius 等)")
+    g_occ.add_argument("--resolution", type=float, default=0.05,
+                       help="栅格分辨率 m/cell (默认 0.05)")
+    g_occ.add_argument("--z-min", type=float, default=None,
+                       help="障碍切片下界 m. 默认按 profile, 注意是 floor=z=0 之上的距离")
+    g_occ.add_argument("--z-max", type=float, default=None,
+                       help="障碍切片上界 m. 默认按 profile")
+    g_occ.add_argument("--footprint-radius", type=float, default=None,
+                       metavar="METERS",
+                       help="自身排除半径 m. 默认按 profile. 0=关")
+    g_occ.add_argument("--floor-z", type=float, default=-0.10,
+                       help="free 标注层下界 (默认 -0.10, 给 RANSAC 残差留容差)")
+    g_occ.add_argument("--no-raycast", action="store_true",
+                       help="跳过沿轨迹 raycast 填 free")
+    g_occ.add_argument("--raycast-range", type=float, default=30.0,
+                       help="raycast 最大距离 m (默认 30)")
+    g_occ.add_argument("--dilate", type=int, default=0,
+                       help="障碍膨胀次数 (默认 0, 不膨胀; nav2 inflation cost 由 nav2 自己处理). "
+                            "set 1 给视觉/老 nav2 留 5cm 缓冲.")
+
+    g_misc = ap.add_argument_group("misc")
+    g_misc.add_argument("--keep-intermediate", action="store_true",
+                        help="保留中间产物 (aligned PCD + 各步 log) 到 output_prefix.aligned/")
+    g_misc.add_argument("--align-floor-py", type=Path, default=ALIGN_FLOOR,
+                        help=f"align_floor.py 路径 (默认 {ALIGN_FLOOR})")
+    g_misc.add_argument("--pcd-to-occgrid-py", type=Path, default=PCD_TO_OCC,
+                        help=f"pcd_to_occgrid.py 路径 (默认 {PCD_TO_OCC})")
+
+    g_pf = ap.add_argument_group("step 0 (optional): per-scan footprint filter")
+    g_pf.add_argument("--per-scan-filter", action="store_true",
+                      help="在 align 前先跑 footprint_filter.py: 用每个 KF 的原始 LiDAR-frame "
+                           "scan + transformations.pcd 在传感器局部系做几何切除. 比全局空间最近邻 "
+                           "(--footprint-radius) 更准, 不依赖 trajectory.pcd 作 KDTree. 需要 "
+                           "SaveMap 输出包含 pcd/ 子目录 + 真 IMU↔LiDAR 外参 yaml.")
+    g_pf.add_argument("--per-scan-extrinsic-yaml", type=Path, default=None,
+                      help="--per-scan-filter 用的外参 yaml (取 mapping.extrinsic_T/R). "
+                           "推荐用 tools/airy_extrinsic 出的 examples/<SN>.yaml")
+    g_pf.add_argument("--per-scan-radius", type=float, default=0.8,
+                      help="--per-scan-filter 的传感器水平半径 m (默认 0.8). "
+                           "实测 0.8m 在手持场景是 sweet spot — 切干净支架 / 操作员伸长的手 / "
+                           "GPS 天线, 但不吃真墙. 0.5m 不够 (仍有 hairy 边缘), 1.0m+ 开始误伤墙.")
+    g_pf.add_argument("--footprint-filter-py", type=Path, default=FOOTPRINT_FILTER,
+                      help=f"footprint_filter.py 路径 (默认 {FOOTPRINT_FILTER})")
+
+    args = ap.parse_args()
+
+    # === 应用 profile 默认值 (用户没显式覆盖时) ===
+    PROFILES = {
+        "handheld": {"z_min": 0.2, "z_max": 1.5, "footprint_radius": 0.3},
+        "dog":      {"z_min": 0.1, "z_max": 0.5, "footprint_radius": 0.4},
+        "vehicle":  {"z_min": 0.3, "z_max": 2.0, "footprint_radius": 1.0},
+        "generic":  {"z_min": 0.1, "z_max": 1.5, "footprint_radius": 0.0},
+    }
+    prof = PROFILES[args.profile]
+    if args.z_min is None:           args.z_min = prof["z_min"]
+    if args.z_max is None:           args.z_max = prof["z_max"]
+    if args.footprint_radius is None: args.footprint_radius = prof["footprint_radius"]
+    print(f"[CFG] profile={args.profile}: z=[{args.z_min}, {args.z_max}]m  "
+          f"footprint={args.footprint_radius}m"
+          + (" (overridden)" if any([
+              args.z_min != prof["z_min"], args.z_max != prof["z_max"],
+              args.footprint_radius != prof["footprint_radius"],
+          ]) else ""))
+
+    # === 准备路径 ===
+    loam_dir = args.loam_dir.expanduser().resolve()
+    out_prefix = args.output.expanduser().resolve()
+    out_prefix.parent.mkdir(parents=True, exist_ok=True)
+
+    if not args.align_floor_py.is_file():
+        print(f"[ERR] 找不到 align_floor.py: {args.align_floor_py}", file=sys.stderr)
+        return 2
+    if not args.pcd_to_occgrid_py.is_file():
+        print(f"[ERR] 找不到 pcd_to_occgrid.py: {args.pcd_to_occgrid_py}", file=sys.stderr)
+        return 2
+
+    # === step 1: 输入检查 ===
+    print(f"[1/3] 检查 SaveMap 输出: {loam_dir}")
+    try:
+        global_pcd = find_pcd(loam_dir, "GlobalMap.pcd")
+        traj_pcd = find_pcd(loam_dir, "trajectory.pcd")
+    except FileNotFoundError as e:
+        print(f"[ERR] {e}", file=sys.stderr)
+        return 2
+    transforms_pcd = loam_dir / "transformations.pcd"
+    if not transforms_pcd.is_file():
+        transforms_pcd = None
+    size_mb = global_pcd.stat().st_size / 1024 / 1024
+    print(f"      GlobalMap.pcd ({size_mb:.1f} MB), trajectory.pcd ({traj_pcd.stat().st_size/1024:.1f} KB)"
+          + (", transformations.pcd" if transforms_pcd else ""))
+
+    # === 多楼层检测 (issue #26) ===
+    # 物理事实: 操作员/机器狗不可能飞起来, trajectory z 必然贴着地面. 所以 trajectory z
+    # 是 "楼层指示器". 单纯 range 不够 (单层操作员蹲下+伸手可达 ~1.8m),
+    # 关键是 **z 是否多峰**: 单层 = 单峰 (跨度内连续分布), 多层 = 多峰 (cluster 间有 gap).
+    try:
+        import numpy as np
+        with open(traj_pcd, "rb") as f:
+            while True:
+                line = f.readline()
+                if line.startswith(b"DATA"):
+                    break
+            arr = np.frombuffer(f.read(), dtype=np.float32).reshape(-1, 8)
+            z = arr[:, 2]
+        z_range = float(z.ptp())
+        z_min, z_max = float(z.min()), float(z.max())
+        print(f"      trajectory z: range=[{z_min:.2f}, {z_max:.2f}]m  span={z_range:.2f}m")
+
+        # 多楼层检测: 分级 z range 警告.
+        #
+        # 物理事实: 操作员/狗不可能飞. 单层场景 z range 受身体尺度约束:
+        #   - 完全静立 + 蹲下: ~0.5m
+        #   - 单手伸举 + 蹲到地: ~1.2m (极限, 几乎不可能维持 1+ 分钟)
+        #   - z range > 1.0m → 几乎肯定走过楼梯/坡道/下沉空间, 即使是 \"半层\"
+        #   - z range > 2.5m → 至少跨一层全高
+        #
+        # 注意: 上下楼梯过程中 trajectory z 是 **连续过渡** 的, KMeans / 1D gap 检测
+        # 不一定能切出离散 cluster. 所以纯 z range 反而是更可靠的指标.
+        if z_range >= 2.5:
+            level = "ERR"
+            msg = (
+                f"[ERR] 轨迹 z range = {z_range:.2f}m, **必然跨多层楼**. "
+                f"单张 2D 投影把所有层墙壁叠在一起, 给 nav2 用 = 错的. "
+                f"用 --z-min / --z-max 限到单层, 或者用 RViz 看 GlobalMap.pcd 3D. "
+                f"分层支持在 issue #26 跟踪."
+            )
+        elif z_range >= 1.0:
+            level = "WARN"
+            msg = (
+                f"[WARN] 轨迹 z range = {z_range:.2f}m. "
+                f">= 1m 时几乎肯定走过楼梯 / 半层下沉 / 坡道, "
+                f"建议核实是不是单层. 如果是多层, 单张 2D 投影会失真. "
+                f"建议: 用 RViz 加载 GlobalMap.pcd, 拖 z-axis 颜色看实际是 1 层 还是 N 层. "
+                f"或手动 --z-min/--z-max 限单层. 分层支持在 issue #26 跟踪."
+            )
+        else:
+            level = "OK"
+            msg = f"      → 单层 (z range {z_range:.2f}m < 1m, 操作员身体抖动范围)"
+        if level == "OK":
+            print(msg)
+        else:
+            print(msg, file=sys.stderr)
+    except Exception as e:
+        print(f"[WARN] 跳过多楼层检测: {e}", file=sys.stderr)
+
+    # 中间产物目录
+    if args.keep_intermediate:
+        scratch = out_prefix.parent / (out_prefix.name + ".aligned")
+        scratch.mkdir(parents=True, exist_ok=True)
+        cleanup = False
+    else:
+        scratch_obj = tempfile.TemporaryDirectory(prefix="build_2d_map_")
+        scratch = Path(scratch_obj.name)
+        cleanup = True
+
+    # === step 0 (optional): per-scan footprint filter ===
+    if args.per_scan_filter:
+        if not args.per_scan_extrinsic_yaml:
+            print(f"[ERR] --per-scan-filter 需要 --per-scan-extrinsic-yaml", file=sys.stderr)
+            return 2
+        if not args.per_scan_extrinsic_yaml.is_file():
+            print(f"[ERR] 外参 yaml 不存在: {args.per_scan_extrinsic_yaml}", file=sys.stderr)
+            return 2
+        if not args.footprint_filter_py.is_file():
+            print(f"[ERR] 找不到 footprint_filter.py: {args.footprint_filter_py}", file=sys.stderr)
+            return 2
+        print(f"[0/3] per-scan footprint filter (LiDAR-frame, r={args.per_scan_radius}m)")
+        filtered_pcd = scratch / "GlobalMap.pcd"
+        cmd0 = [
+            sys.executable, str(args.footprint_filter_py),
+            str(loam_dir),
+            "--extrinsic-yaml", str(args.per_scan_extrinsic_yaml),
+            "-o", str(filtered_pcd),
+            "--sensor-radius", str(args.per_scan_radius),
+        ]
+        rc, _, _ = run_step("filter", cmd0, scratch / "step0_filter.log")
+        if rc != 0:
+            print(f"[ERR] footprint_filter 失败. log: {scratch}/step0_filter.log", file=sys.stderr)
+            return rc
+        # 后续把 filter 输出当 GlobalMap 用
+        # 注意 align_floor 需要 trajectory.pcd / transformations.pcd 在同目录, copy 过来
+        import shutil
+        shutil.copy2(loam_dir / "trajectory.pcd", scratch / "trajectory.pcd")
+        if (loam_dir / "transformations.pcd").is_file():
+            shutil.copy2(loam_dir / "transformations.pcd", scratch / "transformations.pcd")
+        global_pcd = filtered_pcd
+        traj_pcd = scratch / "trajectory.pcd"
+
+    # === step 2: align_floor ===
+    if args.no_align:
+        print(f"[2/3] 跳过 align_floor (--no-align)")
+        cloud_for_occ = global_pcd
+        traj_for_occ = traj_pcd
+    else:
+        print(f"[2/3] align_floor: gravity-align cloud + trajectory")
+        # main 版 align_floor 接口: 吃"输入目录"(自动找里面的 GlobalMap.pcd / trajectory.pcd),
+        # -o 指定输出目录, 输出固定名 GlobalMap.pcd / trajectory.pcd. 不再传单个 pcd 文件,
+        # 也不需要 --transformations (那是 feat 旧接口). 用独立 aligned/ 子目录避免覆盖输入.
+        align_in = global_pcd.parent      # 正常 = loam_dir; per-scan 时 = scratch (已含过滤后 GlobalMap+traj)
+        align_out = scratch / "aligned"
+        cmd = [
+            sys.executable, str(args.align_floor_py),
+            str(align_in),
+            "-o", str(align_out),
+        ]
+        if args.floor_z_range:
+            cmd.extend(["--floor-z-range", str(args.floor_z_range[0]), str(args.floor_z_range[1])])
+        rc, _, _ = run_step("align", cmd, scratch / "step2_align.log")
+        if rc != 0:
+            print(f"[ERR] align_floor 失败. log: {scratch}/step2_align.log", file=sys.stderr)
+            return rc
+        cloud_for_occ = align_out / "GlobalMap.pcd"
+        traj_for_occ = align_out / "trajectory.pcd"
+        if not cloud_for_occ.is_file():
+            print(f"[ERR] align_floor 没生成 {cloud_for_occ}", file=sys.stderr)
+            return 2
+
+    # === step 3: pcd_to_occgrid ===
+    print(f"[3/3] pcd_to_occgrid: 投影 + 切片"
+          + (" + raycast" if not args.no_raycast else ""))
+    cmd = [
+        sys.executable, str(args.pcd_to_occgrid_py),
+        str(cloud_for_occ),
+        "-o", str(out_prefix),
+        "--resolution", str(args.resolution),
+        "--z-min", str(args.z_min),
+        "--z-max", str(args.z_max),
+        "--floor-z", str(args.floor_z),
+        "--dilate", str(args.dilate),
+    ]
+    if not args.no_raycast:
+        cmd.extend([
+            "--raycast", str(traj_for_occ),
+            "--raycast-max-range", str(args.raycast_range),   # main pcd_to_occgrid 接口名
+        ])
+    if args.footprint_radius > 0:
+        cmd.extend([
+            "--footprint-radius", str(args.footprint_radius),
+        ])
+        if args.no_raycast:
+            # raycast 关掉时还要单独传 trajectory 给 footprint 用
+            cmd.extend(["--trajectory", str(traj_for_occ)])
+    rc, _, _ = run_step("occgrid", cmd, scratch / "step3_occgrid.log")
+    if rc != 0:
+        print(f"[ERR] pcd_to_occgrid 失败. log: {scratch}/step3_occgrid.log", file=sys.stderr)
+        # 常见 hint
+        if "裁剪后没有点" in (scratch / "step3_occgrid.log").read_text():
+            print("[HINT] 切片为空, 试 --floor-z-range 手动指定地面 z 区间, "
+                  "或者点云没 align 时用 --no-align + 手动 --z-min/--z-max", file=sys.stderr)
+        return rc
+
+    pgm = Path(str(out_prefix) + ".pgm")
+    yaml = Path(str(out_prefix) + ".yaml")
+    if not pgm.is_file() or not yaml.is_file():
+        print(f"[ERR] 输出文件没生成: {pgm} / {yaml}", file=sys.stderr)
+        return 2
+
+    # === summary ===
+    summary_lines = [
+        f"build_2d_map summary",
+        f"=" * 40,
+        f"input    : {loam_dir.name}",
+        f"output   : {pgm.name} + {yaml.name}",
+        f"profile  : {args.profile}",
+        f"per-scan : {'ON (r=' + str(args.per_scan_radius) + 'm)' if args.per_scan_filter else 'OFF'}",
+        f"align    : {'OFF' if args.no_align else 'ON'}",
+        f"raycast  : {'OFF' if args.no_raycast else 'ON (range ' + str(args.raycast_range) + 'm)'}",
+        f"footprint: {'OFF' if args.footprint_radius == 0 else 'ON (r=' + str(args.footprint_radius) + 'm)'}",
+        f"resolution: {args.resolution} m/px",
+        f"slice    : z ∈ [{args.z_min}, {args.z_max}]m  (above floor=0)",
+        f"floor-z  : {args.floor_z} m (free 标注层下界)",
+    ]
+    print()
+    for line in summary_lines:
+        print(line)
+    summary_path = Path(str(out_prefix) + ".summary.txt")
+    summary_path.write_text("\n".join(summary_lines) + "\n")
+    print(f"\n  summary: {summary_path}")
+    if args.keep_intermediate:
+        print(f"  中间产物: {scratch}/")
+    else:
+        print("  (中间产物已清理, 用 --keep-intermediate 保留)")
+        scratch_obj.cleanup()  # 显式清, 避免 TemporaryDirectory 析构警告
+
+    print(f"\n  下一步: ros2 run nav2_map_server map_server --ros-args -p yaml_filename:={yaml}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/FAST_LIO_SAM/tools/footprint_filter/README.md
+++ b/FAST_LIO_SAM/tools/footprint_filter/README.md
@@ -1,0 +1,71 @@
+# footprint_filter — per-scan 操作员/支架自身排除
+
+把 SaveMap 输出的每个 keyframe 单独的 surf cloud (`pcd/<i>.pcd`，**LiDAR 局部系**) 在传感器局部坐标里做几何切除：
+
+```
+sensor_dist = sqrt(point.x² + point.y²)   # LiDAR 系
+keep = sensor_dist >= sensor_radius
+# (可选) 切传感器上下方
+keep &= (point.z <= sensor_z_above)
+keep &= (point.z >= sensor_z_below)
+# 用 PGO 修正后的 6D 位姿 + IMU↔LiDAR 外参变到世界系
+T_w_lidar = T_w_b(transformations.pcd) * T_b_lidar(extrinsic.yaml)
+world_kept = T_w_lidar @ point[keep]
+```
+
+## 跟 `pcd_to_occgrid --footprint-radius` 的区别
+
+| 维度 | `--footprint-radius` (in pcd_to_occgrid) | `footprint_filter` |
+|---|---|---|
+| 输入 | 已合并的 `GlobalMap.pcd` | 每个 KF 的原始 `pcd/<i>.pcd` |
+| 距离参考 | 切片点 → 最近 trajectory 关键帧 (xy, KDTree) | 切片点 → **观测它的那个 LiDAR** (LIDAR 系自带) |
+| 准确性 | 启发式 — PGO 修正 KF 位姿后，"最近 trajectory 帧" 可能不是真正观测它的帧 | 100% 准 — LiDAR 局部系下点-传感器距离不依赖位姿对齐 |
+| 半径选择 | 紧凑 (~0.3m), 怕误吃近距离真墙 | 宽 (~0.5m) 也安全, 因为只剔除"传感器辐射 0.5m 内"的圆盘 |
+| 依赖 | 只要 `GlobalMap.pcd` + `trajectory.pcd` | 还要 `pcd/` 子目录 + `transformations.pcd` + 真外参 yaml |
+| 计算量 | KDTree 一次 | 810 个 KF 每个变换一次 (~10s) |
+
+per-scan 算法上更"对"。如果场景能拿到完整 SaveMap 输出 + 真外参，**优先用 per-scan**。
+
+## 用法
+
+### 直接用工具
+
+```bash
+python3 footprint_filter.py \
+    ~/Downloads/LOAM/ \
+    --extrinsic-yaml ../airy_extrinsic/examples/airy_300DBEDB0075.yaml \
+    -o /tmp/GlobalMap_filtered.pcd \
+    --sensor-radius 0.5
+```
+
+### 在 build_2d_map 里串起来
+
+```bash
+python3 build_2d_map.py ~/Downloads/LOAM/ -o ~/maps/airy \
+    --per-scan-filter \
+    --per-scan-extrinsic-yaml ../airy_extrinsic/examples/airy_300DBEDB0075.yaml
+```
+
+会先跑 footprint_filter 输出 filtered cloud，再喂给 align_floor + pcd_to_occgrid。
+
+## 可选参数
+
+- `--sensor-radius FLOAT` — 水平半径 (默认 0.5m). 操作员典型 footprint 半径
+- `--sensor-z-above FLOAT` — LiDAR 局部 z 上限. 切掉头顶 / 低天花板. **注意 LiDAR 局部系的 z 朝向跟传感器型号有关**:
+  - RoboSense Airy 半球形: z 朝上 (cap), 地面 z<0 看不到 (盲区), 操作员身体也在盲区
+  - 某些机械式 LiDAR: z 居中, ±15° 视场
+  - 默认不设 (None), 不切 z, 避免误伤
+- `--sensor-z-below FLOAT` — 同上, 下界
+
+## 限制
+
+- 假设 `pcd/<i>.pcd` 是 **LiDAR 局部系**. 这是 FAST-LIO-SAM `surfCloudKeyFrames[i]` 的约定 (`*feats_undistort` 在 lidar 系)
+- 真外参从 yaml 读. 如果用了 `extrinsic_est_en: true`, 在线估计的外参没存盘, 这个工具拿不到 — 用 yaml 里的 default extrinsic 会偏
+- 不补偿 LIO 漂移. 如果 IEKF 在某一段 drift, 后续 KF 的位姿不准, 变换出来的世界系点云就乱. 这个 issue 在 [#22](https://github.com/cvidkal/fast-lio-sam/issues/22) 跟踪
+- 暂只输出 `[x y z intensity]` 4 列, 丢掉 normal / curvature 等. 大多数下游工具不需要
+
+## 何时不该用这工具
+
+- LiDAR 是上半球或下半球形 (Airy 半球) **且操作员身体本来就在盲区**: 那么 sensor-near 点其实是支架 / 头顶 / GPS 天线, 仍可以切, 但收益较小 (~10% drop)
+- 没有 `pcd/` 子目录 (旧 SaveMap 输出 or 自己写的 service): 退回 `pcd_to_occgrid --footprint-radius` 启发式
+- 没拿到真外参 (`extrinsic_est_en: true` 在线估计): 退到全局空间法

--- a/FAST_LIO_SAM/tools/footprint_filter/footprint_filter.py
+++ b/FAST_LIO_SAM/tools/footprint_filter/footprint_filter.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""
+footprint_filter — per-scan 操作员自身排除.
+
+跟 pcd_to_occgrid 里的 \"--footprint-radius\" (全局空间最近 KF 启发) 不同, 这个
+直接在 LiDAR 局部系做几何切除:
+
+    for 每个 keyframe i:
+        raw_i = pcd/<i>.pcd            # LiDAR 系
+        sensor_dist = sqrt(raw_i.x^2 + raw_i.y^2)
+        keep = sensor_dist >= sensor_radius
+        # 可选: 切掉 LiDAR 上方 (头 / 低天花板)
+        if sensor_z_above is not None:
+            keep &= (raw_i.z <= sensor_z_above)
+        # 用 PGO 修正后的 6D 位姿 + IMU↔LiDAR 外参变换到世界系
+        T_w_lidar = T_w_b(transformations.pcd[i]) @ T_b_lidar(extrinsic.yaml)
+        world_i = T_w_lidar @ raw_i[keep]
+        accumulate
+
+输入:
+  - SaveMap 输出目录 (含 pcd/, transformations.pcd)
+  - LiDAR↔IMU 外参 yaml (跟 LIO config 同 schema, 取 mapping.extrinsic_T/R)
+
+输出:
+  - 一个 \"已经清掉操作员\" 的 GlobalMap.pcd, 可直接喂给 align_floor + pcd_to_occgrid
+
+依赖: numpy.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import struct
+import sys
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+
+
+# ============================================================
+# Yaml 读 extrinsic_T / extrinsic_R (省得拉 PyYAML 依赖, 手写解析).
+# 接受两种格式:
+#   1. LIO config yaml (含 /**: ros__parameters: 包裹)
+#   2. airy_extrinsic.py 输出 (mapping: extrinsic_T:..., extrinsic_R:...)
+# ============================================================
+def parse_extrinsic_yaml(path: Path) -> Tuple[np.ndarray, np.ndarray]:
+    """返回 (T_b_lidar 3x3 R, 3x1 t)."""
+    text = Path(path).read_text()
+    # 找 extrinsic_T / extrinsic_R, 取第一处出现的就行
+    R = None
+    T = None
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        if line.startswith("extrinsic_T") and ":" in line:
+            # 可能在同一行 [a, b, c], 也可能下面几行
+            after = line.split(":", 1)[1].strip()
+            T = _parse_floats(after, lines, i)
+        elif line.startswith("extrinsic_R") and ":" in line:
+            after = line.split(":", 1)[1].strip()
+            R = _parse_floats(after, lines, i)
+        if T is not None and R is not None:
+            break
+        i += 1
+    if R is None or T is None:
+        raise ValueError(f"yaml 里没找到 extrinsic_T / extrinsic_R: {path}")
+    if len(T) != 3 or len(R) != 9:
+        raise ValueError(f"extrinsic_T 应该 3 个数 (得 {len(T)}), extrinsic_R 应该 9 个 (得 {len(R)})")
+    return np.array(R, dtype=np.float64).reshape(3, 3), np.array(T, dtype=np.float64)
+
+
+def _parse_floats(after_colon: str, lines, start_idx: int) -> list[float]:
+    """把 [a, b, c] 或者跨多行的 list 抽出 floats."""
+    chunk = after_colon
+    if "[" in chunk and "]" in chunk:
+        return _split_inline(chunk)
+    # 跨行: 收集到 ] 为止
+    if "[" in chunk:
+        chunk_full = chunk
+        i = start_idx + 1
+        while "]" not in chunk_full and i < len(lines):
+            chunk_full += " " + lines[i].strip()
+            i += 1
+        return _split_inline(chunk_full)
+    raise ValueError(f"解析失败: {after_colon!r}")
+
+
+def _split_inline(s: str) -> list[float]:
+    s = s[s.index("[") + 1 : s.rindex("]")]
+    return [float(x.strip()) for x in s.replace(",", " ").split() if x.strip()]
+
+
+# ============================================================
+# transformations.pcd 解析: 字段 [x y z intensity roll pitch yaw time]
+# x..yaw 是 float32, time 是 double (8 bytes). 一行 36 byte.
+# ============================================================
+def read_transformations_pcd(path: Path) -> np.ndarray:
+    """返回 shape=(N, 7) 的数组, 列 [x, y, z, roll, pitch, yaw, time]."""
+    f = open(path, "rb")
+    while True:
+        line = f.readline()
+        if line.startswith(b"DATA"):
+            break
+    raw = f.read()
+    dtype = np.dtype([
+        ("x", "f4"), ("y", "f4"), ("z", "f4"), ("intensity", "f4"),
+        ("roll", "f4"), ("pitch", "f4"), ("yaw", "f4"),
+        ("time", "f8"),
+    ])
+    arr = np.frombuffer(raw, dtype=dtype)
+    out = np.zeros((len(arr), 7), dtype=np.float64)
+    out[:, 0] = arr["x"]
+    out[:, 1] = arr["y"]
+    out[:, 2] = arr["z"]
+    out[:, 3] = arr["roll"]
+    out[:, 4] = arr["pitch"]
+    out[:, 5] = arr["yaw"]
+    out[:, 6] = arr["time"]
+    return out
+
+
+# ============================================================
+# 简易 PCD 读 / 写 (binary, x y z + 其他 float32 列)
+# ============================================================
+def read_pcd_xyz(path: Path) -> np.ndarray:
+    """返回 (N, M) 数组, M 是字段数. 假设全部 float32."""
+    f = open(path, "rb")
+    fields = []
+    sizes = []
+    while True:
+        line = f.readline().decode("ascii", "replace")
+        if line.startswith("FIELDS"):
+            fields = line.split()[1:]
+        elif line.startswith("SIZE"):
+            sizes = [int(s) for s in line.split()[1:]]
+        elif line.startswith("DATA"):
+            break
+    if not all(s == 4 for s in sizes):
+        raise ValueError(f"非纯 float32 PCD: {path} sizes={sizes}")
+    raw = f.read()
+    rec = sum(sizes)
+    n = len(raw) // rec
+    return np.frombuffer(raw[: n * rec], dtype=np.float32).reshape(n, len(fields))
+
+
+def write_pcd_binary(path: Path, points: np.ndarray, fields: list[str]) -> None:
+    """fields 长度 = points.shape[1], 全 float32."""
+    n, m = points.shape
+    assert len(fields) == m
+    header = (
+        "# .PCD v0.7 - footprint_filter output\n"
+        "VERSION 0.7\n"
+        f"FIELDS {' '.join(fields)}\n"
+        f"SIZE {' '.join(['4']*m)}\n"
+        f"TYPE {' '.join(['F']*m)}\n"
+        f"COUNT {' '.join(['1']*m)}\n"
+        f"WIDTH {n}\n"
+        "HEIGHT 1\n"
+        "VIEWPOINT 0 0 0 1 0 0 0\n"
+        f"POINTS {n}\n"
+        "DATA binary\n"
+    )
+    with open(path, "wb") as f:
+        f.write(header.encode("ascii"))
+        f.write(points.astype(np.float32).tobytes())
+
+
+# ============================================================
+# 6D pose -> 4x4 矩阵.
+# 跟 LIO-SAM / FAST-LIO-SAM 的 pcl::getTransformation 对齐:
+#   T = Translate(x, y, z) * Rz(yaw) * Ry(pitch) * Rx(roll)
+# ============================================================
+def pose6d_to_matrix(x, y, z, roll, pitch, yaw) -> np.ndarray:
+    cr, sr = np.cos(roll), np.sin(roll)
+    cp, sp = np.cos(pitch), np.sin(pitch)
+    cy, sy = np.cos(yaw), np.sin(yaw)
+    Rx = np.array([[1, 0, 0], [0, cr, -sr], [0, sr, cr]])
+    Ry = np.array([[cp, 0, sp], [0, 1, 0], [-sp, 0, cp]])
+    Rz = np.array([[cy, -sy, 0], [sy, cy, 0], [0, 0, 1]])
+    R = Rz @ Ry @ Rx
+    T = np.eye(4)
+    T[:3, :3] = R
+    T[:3, 3] = [x, y, z]
+    return T
+
+
+# ============================================================
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("savemap_dir", type=Path,
+                    help="SaveMap service 输出目录 (含 pcd/, transformations.pcd)")
+    ap.add_argument("--extrinsic-yaml", type=Path, required=True,
+                    help="LIO config yaml 或 airy_extrinsic 输出 yaml, "
+                         "提供 mapping.extrinsic_T/R (IMU->LiDAR)")
+    ap.add_argument("-o", "--output", type=Path, required=True,
+                    help="输出 PCD 路径 (将被 align_floor / pcd_to_occgrid 当 GlobalMap 用)")
+    ap.add_argument("--sensor-radius", type=float, default=0.5,
+                    help="传感器水平半径 m. LiDAR 局部系 sqrt(x^2+y^2) < r 的点丢掉. 默认 0.5")
+    ap.add_argument("--sensor-z-above", type=float, default=None, metavar="Z",
+                    help="(可选) LiDAR 局部 z 上限 m, > z 的点丢掉 (头顶 / 低天花板)")
+    ap.add_argument("--sensor-z-below", type=float, default=None, metavar="Z",
+                    help="(可选) LiDAR 局部 z 下限 m, < z 的点丢掉 (脚下噪点 / 地下室)")
+    ap.add_argument("--limit-keyframes", type=int, default=None,
+                    help="(debug) 只处理前 N 个 keyframe")
+    args = ap.parse_args()
+
+    # --- 读外参 ---
+    R_b_lidar, t_b_lidar = parse_extrinsic_yaml(args.extrinsic_yaml)
+    T_b_lidar = np.eye(4)
+    T_b_lidar[:3, :3] = R_b_lidar
+    T_b_lidar[:3, 3] = t_b_lidar
+    print(f"[INFO] T_b_lidar (extrinsic from {args.extrinsic_yaml.name}):")
+    print(f"       t = {t_b_lidar}")
+    print(f"       R = {R_b_lidar.flatten()[:3]} ... {R_b_lidar.flatten()[-3:]}")
+
+    # --- 读 transformations ---
+    pcd_dir = args.savemap_dir / "pcd"
+    trans_path = args.savemap_dir / "transformations.pcd"
+    if not pcd_dir.is_dir():
+        print(f"[ERR] {pcd_dir} 不存在 (SaveMap pcd/ 子目录)", file=sys.stderr)
+        return 2
+    if not trans_path.is_file():
+        print(f"[ERR] {trans_path} 不存在", file=sys.stderr)
+        return 2
+
+    poses = read_transformations_pcd(trans_path)
+    print(f"[INFO] {len(poses)} keyframes in transformations.pcd")
+
+    n_kf = len(poses)
+    if args.limit_keyframes:
+        n_kf = min(n_kf, args.limit_keyframes)
+        print(f"[INFO] --limit-keyframes: only processing first {n_kf}")
+
+    # --- 处理每个 KF ---
+    accum = []
+    fields_out = ["x", "y", "z", "intensity"]  # 简化: 只保留 4 列
+    total_in, total_out = 0, 0
+    sample_print = 5
+    for i in range(n_kf):
+        kf_pcd = pcd_dir / f"{i}.pcd"
+        if not kf_pcd.is_file():
+            print(f"[WARN] {kf_pcd} 缺失, 跳过", file=sys.stderr)
+            continue
+        try:
+            local = read_pcd_xyz(kf_pcd)
+        except Exception as e:
+            print(f"[WARN] 读 {kf_pcd} 失败: {e}", file=sys.stderr)
+            continue
+        # local 是 LiDAR 系, 列 [x y z intensity ...]
+        x, y, z = local[:, 0], local[:, 1], local[:, 2]
+        sensor_dist = np.hypot(x, y)
+        keep = sensor_dist >= args.sensor_radius
+        if args.sensor_z_above is not None:
+            keep &= (z <= args.sensor_z_above)
+        if args.sensor_z_below is not None:
+            keep &= (z >= args.sensor_z_below)
+        kept = local[keep]
+        total_in += len(local)
+        total_out += len(kept)
+
+        # 变换到世界系: T_w_lidar = T_w_b * T_b_lidar
+        x_w, y_w, z_w, r, p, yw, _ = poses[i]
+        T_w_b = pose6d_to_matrix(x_w, y_w, z_w, r, p, yw)
+        T_w_lidar = T_w_b @ T_b_lidar
+        # 变换 (扩列 1, 应用 4x4, 取 3 列)
+        ones = np.ones((len(kept), 1), dtype=np.float64)
+        homo = np.hstack([kept[:, :3].astype(np.float64), ones])
+        world = (T_w_lidar @ homo.T).T[:, :3]
+        # 拼回 intensity
+        out = np.column_stack([world.astype(np.float32), kept[:, 3]])
+        accum.append(out)
+
+        if i < sample_print:
+            print(f"  KF {i:>4}: {len(local):>6} -> {len(kept):>6} "
+                  f"({100*len(kept)/max(1,len(local)):5.1f}% kept)  "
+                  f"pose ({x_w:+6.2f}, {y_w:+6.2f}, {z_w:+5.2f})")
+        elif i == sample_print:
+            print(f"  ... ({n_kf-sample_print} more)")
+
+    print(f"\n[OK] 总计 {total_in:,} -> {total_out:,} pts ({100*total_out/max(1,total_in):.1f}% kept)")
+    print(f"     drop rate: {100*(1 - total_out/max(1,total_in)):.1f}%  (越高越多操作员被识别)")
+    if not accum:
+        print("[ERR] 没产出任何点, 检查输入", file=sys.stderr)
+        return 2
+
+    points_world = np.concatenate(accum, axis=0)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    write_pcd_binary(args.output, points_world, fields_out)
+    print(f"[OK] 写出 {args.output}  ({len(points_world):,} pts)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/FAST_LIO_SAM/tools/pcd_to_occgrid/pcd_to_occgrid.py
+++ b/FAST_LIO_SAM/tools/pcd_to_occgrid/pcd_to_occgrid.py
@@ -329,6 +329,80 @@ def _bresenham_mark(x0: int, y0: int, x1: int, y1: int, out: np.ndarray) -> None
 
 
 # ============================================================
+# Footprint exclusion: 扔掉切片里"贴近任一 keyframe"的点.
+#
+# 手持采集时操作员身体 (脚/胸/肩/背包) 或机器狗机身在 LiDAR 视野里, 投影到 2D 后
+# 变成贴着轨迹的"鬼墙". 这些点的特征: 在切片高度内, 且**始终离 trajectory 很近**
+# (附着在传感器上, 全程跟着走). 真墙离最近 keyframe 一般有 ~0.3m+. 简单全局启发:
+# 把"距最近 KF < radius"的切片点删掉. 推荐手持 0.3m, 机器狗 0.4m.
+#
+# 注: per-scan 的精确版见 tools/footprint_filter/ (在传感器局部系按外参切, 不依赖
+#     全局最近邻). 此处是轻量全局版, 给 build_2d_map 默认 profile 用.
+# ============================================================
+def exclude_footprint(
+    points_xyz: np.ndarray,
+    traj_xy: np.ndarray,
+    radius: float,
+) -> np.ndarray:
+    """从 points_xyz 中扔掉离任一 keyframe (xy) 距离 < radius 的点."""
+    if radius <= 0 or len(traj_xy) == 0:
+        return points_xyz
+    try:
+        from scipy.spatial import cKDTree
+    except ImportError:
+        keep = np.ones(len(points_xyz), dtype=bool)
+        for kf in traj_xy:
+            d = np.hypot(points_xyz[:, 0] - kf[0], points_xyz[:, 1] - kf[1])
+            keep &= d >= radius
+        return points_xyz[keep]
+    tree = cKDTree(traj_xy)
+    nearest_dist, _ = tree.query(points_xyz[:, :2], k=1)
+    return points_xyz[nearest_dist >= radius]
+
+
+# ============================================================
+# Auto-crop: 把网格四周"全 unknown"的边裁掉, 只保留有信息 (occ/free) 的区域.
+#
+# 为什么需要: project_to_grid 用 *完整点云* 的 xy extent 定网格大小, 但只有 z 切片
+# 后的点 (障碍) + floor 层 / raycast (free) 才会被真正标注. 机器狗在室内透过门窗能
+# 看到 ~30m 外的真实远点 (z 多落在切片外), 这些点把网格撑到几十米, 而 occ/free 只占
+# 一角 -> 输出图 90%+ 是 unknown 空白边 (实测 dog bag: 43x35m / unknown 96.2%).
+#
+# 裁到 (occ ∪ free) 的包围盒 + pad 边距即可: 不丢任何信息 (外面本就全 unknown),
+# 内部被墙包住的 unknown 也原样保留 (只裁外框). origin 按裁剪量同步平移.
+# 注意: 此处 grid 行号 iy = (y - y_min)/res, 即 row 0 = y_min (世界系下边),
+#       origin(x_min,y_min) 落在 (row=0, col=0), 所以裁剪后:
+#         new_x_min = x_min + c0*res ;  new_y_min = y_min + r0*res
+#       (PGM 的上下翻转在 save_map 里做, 这里仍是世界系正向, 不用管翻转.)
+# ============================================================
+def autocrop_unknown_border(
+    grid: np.ndarray,
+    origin_xy: tuple[float, float],
+    resolution: float,
+    pad_m: float = 0.5,
+) -> tuple[np.ndarray, tuple[float, float]]:
+    """裁掉全 unknown(255) 的外边. grid 内部约定: 0=free,100=occ,255=unknown."""
+    content = grid != 255
+    if not content.any():
+        print('[WARN] autocrop: 整张图都是 unknown, 跳过裁剪')
+        return grid, origin_xy
+    H, W = grid.shape
+    ys, xs = np.where(content)
+    r0, r1 = int(ys.min()), int(ys.max()) + 1
+    c0, c1 = int(xs.min()), int(xs.max()) + 1
+    pad = int(round(max(0.0, pad_m) / resolution))
+    r0 = max(0, r0 - pad); c0 = max(0, c0 - pad)
+    r1 = min(H, r1 + pad); c1 = min(W, c1 + pad)
+    cropped = grid[r0:r1, c0:c1]
+    new_origin = (origin_xy[0] + c0 * resolution,
+                  origin_xy[1] + r0 * resolution)
+    print(f'[INFO] autocrop: {W}x{H} -> {cropped.shape[1]}x{cropped.shape[0]} px '
+          f'(pad {pad_m}m), origin {origin_xy[0]:.2f},{origin_xy[1]:.2f} '
+          f'-> {new_origin[0]:.2f},{new_origin[1]:.2f}')
+    return cropped, new_origin
+
+
+# ============================================================
 # 写出 nav2 兼容的 PGM + YAML
 # ============================================================
 def save_map(
@@ -407,6 +481,19 @@ def main() -> int:
                    help='检测到多层时报错并退出 (默认仅 warn 后继续, 但结果不可信).')
     p.add_argument('--dilate', type=int, default=1,
                    help='障碍膨胀次数 (默认 1, 给 nav2 留点 inflation 缓冲)')
+    p.add_argument('--footprint-radius', type=float, default=0.0, metavar='METERS',
+                   help='全局 footprint 排除半径 m (默认 0=关). >0 时把切片内"距最近 '
+                        'keyframe < radius"的点删掉, 抑制操作员身体/机身投影成的鬼墙. '
+                        '需要 --raycast 或 --trajectory 提供 KF 位置. 手持 0.3, 狗 0.4. '
+                        '精确 per-scan 版见 tools/footprint_filter/.')
+    p.add_argument('--trajectory', metavar='TRAJ_PCD', default=None,
+                   help='trajectory.pcd 路径, 仅用于 --footprint-radius 但不跑 raycast 时. '
+                        '跟 --raycast 二选一, --raycast 时自动复用其轨迹.')
+    p.add_argument('--no-crop', action='store_true',
+                   help='不裁剪. 默认会把四周全 unknown 的空白边自动裁掉 '
+                        '(见 autocrop_unknown_border). 加此项保留完整点云 extent.')
+    p.add_argument('--crop-pad', type=float, default=0.5, metavar='METERS',
+                   help='autocrop 后在内容四周保留的边距 m (默认 0.5).')
     args = p.parse_args()
 
     print(f'[INFO] 加载 PCD: {args.pcd}')
@@ -426,6 +513,24 @@ def main() -> int:
         print(f'       (相对地面 +z_min={args.z_min}, +z_max={args.z_max}, floor_z={args.floor_z})')
     else:
         z_min, z_max, floor_z = args.z_min, args.z_max, args.floor_z
+
+    # footprint exclusion (投影前): 扔掉切片里"贴近任一 KF"的点 (操作员身体/机身鬼墙).
+    # 只动切片层 (z_min~z_max) 的点, 切片外 (floor 层等) 不碰.
+    if args.footprint_radius > 0:
+        traj_path = args.trajectory or args.raycast
+        if not traj_path:
+            print('[ERR] --footprint-radius 需要 --trajectory 或 --raycast 提供 KF 位置',
+                  file=sys.stderr)
+            return 2
+        ft_traj = load_pcd_xyz(traj_path)[:, :2]
+        slice_mask = (xyz[:, 2] >= z_min) & (xyz[:, 2] <= z_max)
+        slice_pts = xyz[slice_mask]
+        non_slice = xyz[~slice_mask]
+        kept = exclude_footprint(slice_pts, ft_traj, args.footprint_radius)
+        print(f'[INFO] footprint exclusion r={args.footprint_radius}m '
+              f'(用 {len(ft_traj)} KF): 切片点 {len(slice_pts):,} -> {len(kept):,} '
+              f'(扔 {len(slice_pts)-len(kept):,})')
+        xyz = np.concatenate([kept, non_slice], axis=0)
 
     print(f'[INFO] 投影到 2D 占据栅格 res={args.resolution} z=[{z_min:.2f},{z_max:.2f}]')
     grid, origin = project_to_grid(
@@ -474,6 +579,10 @@ def main() -> int:
         print(f'       raycast 完成: occupied={n_occ:,}  free={n_free:,}')
 
     grid = morph_clean(grid, dilate_iter=args.dilate)
+    if not args.no_crop:
+        grid, origin = autocrop_unknown_border(
+            grid, origin, args.resolution, pad_m=args.crop_pad,
+        )
     save_map(grid, origin, args.resolution, args.output)
     return 0
 


### PR DESCRIPTION
Closes #32.

把滞留 `feat/airy-handheld-and-2d-mapping` 的 2D-mapping 工具调和进 `main`, 适配 main
已分叉的 `align_floor` / `pcd_to_occgrid` 接口。**off `main` 的干净分支, 单 commit, 不带
feat 的其它 14 个 commit。**

## 改了什么

**新增工具**
- `tools/build_2d_map/` — 一键 wrapper (align_floor → pcd_to_occgrid), 含多楼层警告 (#26)。
  调用已适配 main 接口: `align_floor` 改成"目录入参 + `-o`", raycast flag 用 `--raycast-max-range`。
- `tools/footprint_filter/` — per-scan 操作员/机身自遮挡排除 (传感器局部系按外参切)。
- `tools/README.md` — 工具索引 + 指向 build_2d_map (解决 #32 "默认 checkout 搜不到 2d map 工具")。

**`pcd_to_occgrid` (main 版) 增强**
- 加回 `--footprint-radius` (全局最近-KF 启发, 默认 0=关) 供 build_2d_map 的 dog/handheld
  profile 用; 精确 per-scan 版仍走独立 `footprint_filter`。
- `autocrop_unknown_border` (默认开, `--no-crop`/`--crop-pad`): 裁掉四周全 unknown 空白边。
  修狗室内远点 (透过门窗看 ~30m, z 多在切片外) 把网格撑到几十米 / 90%+ unknown 的问题。
  等价 #38 (feat `eba8c0e`)。

**`align_floor` 修复 (bug)**
- `fit_plane_ransac` 加近竖直约束 `|n_z| >= 0.7`。原纯"最大内点平面"在室内会把**竖直墙面
  当地面** (墙底点在"最低 20% z"候选带里往往比地面点还多), 翻成 +z 后得 **~86° 假地面**,
  整张图旋歪 → 2D 投影只剩斜薄片 (实测狗 bag 出图只剩 2 个房间)。地面残留倾斜仅几度,
  阈值 45° 极安全。

## 测试

两段 dog bag (`~/maps/dog_20260531/*/loam`) 跑 `build_2d_map --profile dog --resolution 0.05`:

| bag | 出图 | occ / free |
|---|---|---|
| airy_20260530_234024 | 233×166 | 4.4% / 31.9% |
| airy_20260525_220856 | 261×238 | 4.9% / 33.8% |

均为完整多房间 5cm 图, 与 feat 工具链结果一致 (verified: feat-align + 本 PR 的 pcd_to_occgrid
逐像素复现 feat-tool 输出)。

## 关于 #32 的 cherry-pick 步骤

#32 提议 cherry-pick `ed37aea`/`b5f4c88` 两个 laserMapping 修复 —— **已无必要**:
main 经 #35 已含等价实现 (PGO `IndeterminantLinearSystem` try/catch @ `laserMapping.cpp:742`;
退出 `savePCD` 自动存 PGO 图 @ `:2750`)。故本 PR **不动 `laserMapping.cpp`**, #32 的
`changed in both` 冲突随之消失。#25 (GTSAM) 在 main 上实质已解。

合并后可删 `feat/airy-handheld-and-2d-mapping` (#32 step 5)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)