### PR TITLE
feat(tooling): worktree 自包含编译/运行 helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,32 @@ libpcl-dev libeigen3-dev libgoogle-glog-dev libgeographic-dev
 ```
 还要 `livox_ros_driver2` 在 ws 里 (msg-only stub 也行, 见 `dog_mapping_ws/src/livox_ros_driver2/`).
 
+### Worktree 下编译/运行 (多分支并行, 必读)
+
+git worktree 给每个分支独立源码树, 但 colcon 的"一个 `ws/src/<包>` + ws 根放
+build/install/log"工作方式跟它冲突。**直接 `cd ~/fls_ws && colcon build` 编的是那个
+写死软链指向的树 (通常是 main), 不是你当前 worktree 改的分支。** 用仓内 helper 让每个
+worktree 自包含 (已验证 2026-05-31: in-place 编 2.5min / EXIT 0, 产物不弄脏 git):
+
+```bash
+# 编当前 worktree (产物落 FAST_LIO_SAM/{build,install,log}, 被 .gitignore 吃掉)
+bin/wt_build.sh                              # Release; 透传额外 colcon 参数, 如 --symlink-install
+# 跑当前 worktree (按分支名 hash 出唯一 ROS_DOMAIN_ID, 自动隔离 DDS, 多分支同时跑不抢 topic)
+bin/wt_run.sh launch fast_lio_sam mapping_bag.launch.py bag:=... config_file:=...
+# 别的终端对同一 worktree 操作 (echo/hz/service call) 前, 先 export wt_run 打印的那行 ROS_DOMAIN_ID
+```
+
+**三条铁律** (不照做 worktree 就会互相污染):
+1. **必须从 `FAST_LIO_SAM/` 里跑 colcon** (helper 已用 `BASH_SOURCE/..` 锁定包根)。
+   在 worktree 根跑产物落根目录 → 那里没 `.gitignore` (它在 `FAST_LIO_SAM/` 里) → 弄脏 git。
+2. **source `~/fls_ws/install` 当 underlay** 白嫖已编好的 `livox_ros_driver2` (唯一非 apt
+   工作区依赖) + apt 依赖。会有一句 `overriding fast_lio_sam` warning, 无害。覆盖路径用 `FLS_UNDERLAY`。
+3. **每个 worktree 唯一 `ROS_DOMAIN_ID`** (helper 自动按分支 hash 到 1..101, 永不为 0 →
+   不撞默认域 0 的 main)。否则 live 跑会抢 `/Odometry` `/rslidar_points`, 触发 `lidar loop back` 雪崩。
+
+注: `legacy/ros1/package.xml` 包名也是 `fast_lio_sam` (catkin 版), 已用 `legacy/COLCON_IGNORE`
+屏蔽整个 `legacy/` 子树, 避免 colcon 撞 duplicate package。
+
 ### LIVE 建图 (Airy, driver 必须先起)
 ```bash
 ros2 launch fast_lio_sam mapping_airy.launch.py

--- a/FAST_LIO_SAM/bin/wt_build.sh
+++ b/FAST_LIO_SAM/bin/wt_build.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# wt_build.sh — 在「当前这棵 worktree」里自包含地编译 fast_lio_sam。
+#
+# 为什么需要它: git worktree 给每个分支独立源码树, 但 colcon 默认要
+# `ws/src/<包>` 布局 + ws 根放 build/install/log。直接 `colcon build` 会编到
+# 那个写死软链指向的 ws (通常是 main), 不是你当前改的分支。本脚本把产物固定
+# 落在「脚本所属的那棵树」的 FAST_LIO_SAM/{build,install,log} (被 .gitignore 吃掉),
+# 从而每个 worktree 各编各的, 互不污染。
+#
+# 用法:
+#   bin/wt_build.sh                 # Release 编当前 worktree
+#   BUILD_TYPE=Debug bin/wt_build.sh
+#   bin/wt_build.sh --symlink-install   # 透传额外 colcon 参数
+#
+# 依赖来源: fast_lio_sam 唯一的非 apt 工作区依赖是 livox_ros_driver2 (msg stub)。
+# 脚本 source 一个已编好的 underlay 拿它; 用 FLS_UNDERLAY 覆盖路径。
+set -eo pipefail
+
+# 包根 = 本脚本所在目录的上一级 (bin/.. = FAST_LIO_SAM)。
+# 用 BASH_SOURCE 而非 pwd, 这样不管在哪调都锁定「脚本自己那棵 worktree」。
+PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+ROS_SETUP="${ROS_SETUP:-/opt/ros/humble/setup.bash}"
+FLS_UNDERLAY="${FLS_UNDERLAY:-$HOME/fls_ws/install/setup.bash}"
+BUILD_TYPE="${BUILD_TYPE:-Release}"
+
+echo "[wt_build] 包根       : $PKG_ROOT"
+echo "[wt_build] 分支       : $(git -C "$PKG_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+echo "[wt_build] BUILD_TYPE : $BUILD_TYPE"
+
+# 注意: ROS setup 脚本引用未定义变量, 不能开 set -u。
+# shellcheck disable=SC1090
+source "$ROS_SETUP"
+
+if [ -f "$FLS_UNDERLAY" ]; then
+  echo "[wt_build] underlay   : $FLS_UNDERLAY (拿 livox_ros_driver2 等依赖)"
+  # shellcheck disable=SC1090
+  source "$FLS_UNDERLAY"
+else
+  echo "[wt_build] !! 找不到 underlay $FLS_UNDERLAY"
+  echo "[wt_build]    若 livox_ros_driver2 不在别处, 编译会失败。设 FLS_UNDERLAY 指向有它的 install/setup.bash。"
+fi
+
+cd "$PKG_ROOT"
+# 从包根跑 colcon: 产物落 ./build ./install ./log, 被 FAST_LIO_SAM/.gitignore 吃掉。
+# legacy/ 有 COLCON_IGNORE, 不会撞同名 catkin 包 fast_lio_sam。
+set -x
+colcon build --packages-select fast_lio_sam \
+  --cmake-args -DCMAKE_BUILD_TYPE="$BUILD_TYPE" "$@"
+{ set +x; } 2>/dev/null
+
+echo
+echo "[wt_build] 完成。运行用:  bin/wt_run.sh launch fast_lio_sam <launch> ..."
+echo "[wt_build] 或手动 source: source \"$PKG_ROOT/install/setup.bash\""

--- a/FAST_LIO_SAM/bin/wt_run.sh
+++ b/FAST_LIO_SAM/bin/wt_run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# wt_run.sh — 在「当前这棵 worktree」的 install 环境里跑 ros2, 自动隔离 DDS 域。
+#
+# 为什么需要它: 多个 worktree 同时 live 跑会抢同名 topic (/Odometry /rslidar_points …),
+# fastlio 触发 "lidar loop back" 雪崩。给每个分支一个唯一 ROS_DOMAIN_ID 就互不可见。
+# 域 id 由分支名 hash 出 (1..101 稳定可复现, 永不为 0 → 不撞默认域 0 的 main)。
+#
+# 用法:
+#   bin/wt_run.sh launch fast_lio_sam mapping_bag.launch.py bag:=... config_file:=...
+#   bin/wt_run.sh run   fast_lio_sam fastlio_mapping
+#   ROS_DOMAIN_ID=42 bin/wt_run.sh launch ...     # 手动指定域则不再 hash
+#
+# 在「别的终端」对同一 worktree 操作 (echo / hz / service call) 时, 先 export 脚本
+# 打印的那行 ROS_DOMAIN_ID, 否则收不到消息 (跟生产陷阱 #3 同类坑)。
+set -eo pipefail
+
+PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+ROS_SETUP="${ROS_SETUP:-/opt/ros/humble/setup.bash}"
+FLS_UNDERLAY="${FLS_UNDERLAY:-$HOME/fls_ws/install/setup.bash}"
+
+BRANCH="$(git -C "$PKG_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo default)"
+# 已显式给 ROS_DOMAIN_ID 就尊重它; 否则按分支名 hash 到 1..101。
+if [ -z "${ROS_DOMAIN_ID:-}" ]; then
+  ROS_DOMAIN_ID=$(( ($(printf '%s' "$BRANCH" | cksum | cut -d' ' -f1) % 101) + 1 ))
+fi
+export ROS_DOMAIN_ID
+
+INSTALL_SETUP="$PKG_ROOT/install/setup.bash"
+if [ ! -f "$INSTALL_SETUP" ]; then
+  echo "[wt_run] !! 没找到 $INSTALL_SETUP — 先跑 bin/wt_build.sh" >&2
+  exit 1
+fi
+
+echo "[wt_run] 分支          : $BRANCH"
+echo "[wt_run] ROS_DOMAIN_ID : $ROS_DOMAIN_ID"
+echo "[wt_run] 其它终端先跑   : export ROS_DOMAIN_ID=$ROS_DOMAIN_ID"
+echo "[wt_run] ----------------------------------------"
+
+# shellcheck disable=SC1090
+source "$ROS_SETUP"
+[ -f "$FLS_UNDERLAY" ] && source "$FLS_UNDERLAY"  # shellcheck disable=SC1090
+# shellcheck disable=SC1090
+source "$INSTALL_SETUP"
+
+exec ros2 "$@"


### PR DESCRIPTION
## Summary
- git worktree 多分支跟 colcon "一个 ws/src/包 + ws 根放 build/install/log" 的工作方式冲突 (写死软链只指向 main / 同名包不能共存一 ws / 产物易弄脏 git / legacy 同名 catkin 包撞 duplicate)。
- `bin/wt_build.sh` + `bin/wt_run.sh`: 每个 worktree 自包含 in-place 编译 + 按分支名 hash 唯一 `ROS_DOMAIN_ID` 隔离 DDS。
- `legacy/COLCON_IGNORE` 解决同名包 duplicate；`CLAUDE.md` 新增「Worktree 下编译/运行」一节 + 三铁律。

closes #42

## Test plan
- [x] 当前 worktree in-place `colcon build` EXIT 0 / 2min26s (仅无害 warning)
- [x] 编完 `git status` 无 `build/install/log` (被 FAST_LIO_SAM/.gitignore 吃掉)
- [x] underlay 正确解析 `livox_ros_driver2`
- [x] domain id 计算确定且不为 0 (本分支=14, main=55)
- [ ] 后续: 两个 worktree 同时 live 跑验证 DDS 隔离 (需真机/双 bag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)