### PR TITLE
refactor(mapping): 移除 HBA 格式输出 (pcd/ + pose.json)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,12 @@ ros2 launch open3d_loc airy_fastlio_loc_cold_start.launch.py rate:=1.0
 
 **rsasaki 路线弃用原因**: NDT_OMP 在 bag1 prior + bag2 scan 上 fitness median 0.6 但对应 RMS ~0.8m, 帧间跳 1-2m. Open3D ICP 同数据 fitness 0.6-0.9 / rmse 0.27m, 是质的差距. 弃用. 留 lidar_localization_ros2 包当 fallback / 参考.
 
+> **2026-05-31 注 (issue #44)**: 建图侧已**移除 HBA 格式输出** (`saveMapDirectory/pcd/` 逐关键帧点云 +
+> `pose.json`). 本段 ScanContext 路线 (`auto_init_pose.py` / `prior_kf_dir` / `prior_pose_json` /
+> line 390 的 `pose.json` KF pose) 依赖它做 place recognition, 现已**无自动来源** — 但该路线本就随
+> rsasaki 栈弃用. 当前主方案**架构 B 用 `GlobalMap.pcd`, 不受影响**. `saveMap` 仍照常输出
+> `GlobalMap.pcd` / `filterGlobalMap.pcd` / `trajectory.pcd` / `transformations.pcd`.
+
 **关键 3 件套 (rsasaki 时代用过, open3d_loc 不需要了)**:
 - `lidar_localization_ros2` (上游): NDT_OMP scan-to-map 跟踪, 接受 `/initialpose` (RViz click 或程式发) — 已弃用
 - `scripts/auto_init_pose.py`: 启动时用 ScanContext++ (`pyscancontext` pip 装) 把 bag1 226 KFs 建 DB, 头几帧自动匹配 → 发 `/initialpose` — 可复用做 init

--- a/FAST_LIO_SAM/src/laserMapping.cpp
+++ b/FAST_LIO_SAM/src/laserMapping.cpp
@@ -1827,61 +1827,6 @@ void savePoseService(const std::shared_ptr<fast_lio_sam::srv::SavePose::Request>
 }
 
 /**
- * 输出HBA格式的数据
- */
-void outputHBA(const vector<pcl::PointCloud<PointType>::Ptr>& surfCloudKeyFrames,
-               const pcl::PointCloud<PointTypePose>::Ptr& cloudKeyPoses6D, const string& saveMapDirectory) {
-    // 创建pcd目录
-    string pcdDir = saveMapDirectory + "/pcd";
-    (void)system((string("mkdir -p ") + pcdDir).c_str());
-
-    // 保存每个关键帧的点云
-    for (size_t i = 0; i < surfCloudKeyFrames.size(); ++i) {
-        string pcdFile = pcdDir + "/" + to_string(i) + ".pcd";
-        pcl::io::savePCDFileBinary(pcdFile, *surfCloudKeyFrames[i]);
-    }
-
-    // 创建pose.json文件
-    string poseFile = saveMapDirectory + "/pose.json";
-    FILE* file = fopen(poseFile.c_str(), "w");
-    if (!file) {
-        cout << "Failed to open pose.json for writing" << endl;
-        return;
-    }
-
-    for (size_t i = 0; i < cloudKeyPoses6D->size(); ++i) {
-        // 获取body系下的位姿
-        PointTypePose pose_body = cloudKeyPoses6D->points[i];
-
-        // 构造T_w_b (world to body)
-        Eigen::Affine3f T_w_b_ = pcl::getTransformation(pose_body.x, pose_body.y, pose_body.z, pose_body.roll,
-                                                        pose_body.pitch, pose_body.yaw);
-        Eigen::Isometry3d T_w_b;
-        T_w_b.matrix() = T_w_b_.matrix().cast<double>();
-
-        // 构造T_b_lidar (body to lidar)
-        Eigen::Isometry3d T_b_lidar(state_point.offset_R_L_I);
-        T_b_lidar.pretranslate(state_point.offset_T_L_I);
-
-        // 计算T_w_lidar = T_w_b * T_b_lidar
-        Eigen::Isometry3d T_w_lidar = T_w_b * T_b_lidar;
-
-        // 提取平移
-        Eigen::Vector3d translation = T_w_lidar.translation();
-
-        // 提取旋转并转换为四元数
-        Eigen::Quaterniond quat(T_w_lidar.rotation());
-
-        // 写入JSON格式
-        fprintf(file, "%lf %lf %lf %lf %lf %lf %lf\n", translation.x(), translation.y(), translation.z(), quat.w(),
-                quat.x(), quat.y(), quat.z());
-    }
-    fclose(file);
-
-    cout << "HBA format output completed: " << surfCloudKeyFrames.size() << " PCD files and pose.json saved." << endl;
-}
-
-/**
  * 保存全局关键帧特征点集合
  */
 void saveMapService(const std::shared_ptr<fast_lio_sam::srv::SaveMap::Request> req, std::shared_ptr<fast_lio_sam::srv::SaveMap::Response> res) {
@@ -1960,9 +1905,6 @@ void saveMapService(const std::shared_ptr<fast_lio_sam::srv::SaveMap::Request> r
     rclcpp::Time timeLaserInfoStamp = rclcpp::Time(static_cast<int64_t>((lidar_end_time) * 1e9), RCL_ROS_TIME);
     string odometryFrame = "camera_init";
     publishCloud(pubOptimizedGlobalMap, globalSurfCloudDS, timeLaserInfoStamp, odometryFrame);
-
-    // 输出HBA格式的数据
-    outputHBA(surfCloudKeyFrames, cloudKeyPoses6D, saveMapDirectory);
 
     // res->success 已经在 ret==0 处赋好, 这里 void 收尾
 }


### PR DESCRIPTION
## Summary
- `saveMapService` 不再写逐关键帧 PCD 目录 (`saveMapDirectory/pcd/`) 和 `pose.json`，并删除 `outputHBA` 函数（`laserMapping.cpp` -58 行）。
- 这条 HBA 格式输出只被已弃用的 rsasaki ScanContext 重定位路线（`auto_init_pose.py` / `prior_kf_dir` / `prior_pose_json`）消费；当前主方案架构 B 用 `GlobalMap.pcd`，不需要它。
- 顺带消除 #44 根因：`outputHBA` 写 `pcd/` 前只 `mkdir` 不清空，跨次建图且上次关键帧更多时残留 stale PCD。输出整个移除后该问题自然消失。
- `saveMap` 仍照常输出 `GlobalMap.pcd` / `filterGlobalMap.pcd` / `trajectory.pcd` / `transformations.pcd`。
- CLAUDE.md 同步加注 ScanContext prior 来源已移除。

Closes #44

## Test plan
- [x] worktree 自包含编译通过（`bin/wt_build.sh`，EXIT 0）
- [x] 离线建图验证（`mapping_offline.launch.py`，bag `airy_20260530_234024`）：`GlobalMap.pcd` 等正常刷新；`pose.json` + `pcd/` mtime 保持上次值（确认不再写入）
- [x] 无残留 `outputHBA` 引用

🤖 Generated with [Claude Code](https://claude.com/claude-code)