### PR TITLE
feat(map_bag): 2D 切法换成「每格相对局部地面」自适应,修斜坡/欠采区漏墙

### DIFF
--- a/FAST_LIO_SAM/bin/map_bag.sh
+++ b/FAST_LIO_SAM/bin/map_bag.sh
@@ -4,22 +4,23 @@
 # 只需给 bag 目录即可。封装了本仓库验证过的最优流程 (见 issue #49 / #50, memory):
 #   1) 离线 data_mode=1 直读 bag (lock-step 喂帧, 不掉帧, 可复现) —— 不是 ros2 bag play
 #   2) 回环 ICP fitness 0.1 (室外大场景甜点; 0.02 太严会拒真回环, 0.3 太松)
-#   3) 2D 走"相对最近轨迹点 z 的高度带"切片 + raycast (适配坡地/室外, 也兼容平地)
+#   3) 2D 走"每格相对当地局部地面的高度带"切片 + raycast
+#      (自适应斜坡/起伏地形, 不依赖机器人是否走近该处; 取代旧的"相对最近轨迹点"切法)
 #
 # 用法:
 #   bin/map_bag.sh <bag_dir> [选项]
 #     --fitness F     回环 ICP fitness 阈值 (默认 0.1)
 #     --out DIR       输出目录 (默认 ~/dog_maps/<bag名>; 必须在 $HOME 下)
 #     --scan-line N   Airy 线数 (默认沿用 config 的 96; 192 模式传 192)
-#     --rel-min M     2D 相对地面带下界 (默认 -0.5 m)
-#     --rel-max M     2D 相对地面带上界 (默认  1.5 m)
+#     --rel-min M     2D 障碍带下界 = 当地地面上方多少 m 起算 (默认 0.3, 避开地面层)
+#     --rel-max M     2D 障碍带上界 = 当地地面上方多少 m 止 (默认 2.5)
 #     --res R         2D 分辨率 (默认 0.05 m/px)
 #     --no-2d         只建 3D, 跳过 2D
 #     --deploy        生成后部署到 /opt/dog/map/<bag名> 并重指 current_map
 #
 # 例:
 #   bin/map_bag.sh /home/nvidia/mou/dog/bags/airy_20260604_202204 --deploy
-#   bin/map_bag.sh ~/bags/room1 --rel-min 0.1 --rel-max 1.5   # 室内平地也行
+#   bin/map_bag.sh ~/bags/room1 --rel-min 0.2 --rel-max 2.0   # 收紧障碍带
 #
 # 前提: fast_lio_sam 已编译且离线模式可用。若 [1/3] 报 "data_mode=1 ... disabled",
 #       说明 install 二进制旧了, 先重编:
@@ -37,7 +38,7 @@ WS_SETUP="${WS_SETUP:-/home/cgj/ws/fls/install/setup.bash}"
 PKG_SRC="${PKG_SRC:-/home/cgj/ws/fls/src/FAST_LIO_SAM}"
 DOMAIN="${ROS_DOMAIN_ID:-42}"
 
-FITNESS=0.1; OUT=""; SCAN_LINE=""; REL_MIN=-0.5; REL_MAX=1.5; RES=0.05; DO_2D=1; DO_DEPLOY=0
+FITNESS=0.1; OUT=""; SCAN_LINE=""; REL_MIN=0.3; REL_MAX=2.5; RES=0.05; DO_2D=1; DO_DEPLOY=0
 
 usage() { sed -n '2,30p' "$0"; exit 1; }
 [ $# -ge 1 ] || usage
@@ -99,27 +100,39 @@ LC=$(grep -c "LOOP cur=" "$OUT/map_run.log" 2>/dev/null)
 FR=$(grep -oE "offline bag finished: lidar=[0-9]+ imu=[0-9]+" "$OUT/map_run.log" | tail -1)
 echo "    OK: GlobalMap.pcd $(du -h "$OUT/GlobalMap.pcd" | cut -f1) | 接受回环 ${LC:-0} | ${FR:-?}"
 
-# --- [2/3] 2D occupancy (相对地面带 + raycast) ---
+# --- [2/3] 2D occupancy (局部地面自适应带 + raycast) ---
 if [ "$DO_2D" = 1 ]; then
-  echo "[2/3] 生成 2D occupancy (相对地面带 + raycast) ..."
+  echo "[2/3] 生成 2D occupancy (局部地面自适应带 + raycast) ..."
   GB="$OUT/groundband.pcd"
-  python3 - "$OUT/GlobalMap.pcd" "$OUT/trajectory.pcd" "$GB" "$REL_MIN" "$REL_MAX" "$PKG_SRC" <<'PY'
+  python3 - "$OUT/GlobalMap.pcd" "$GB" "$REL_MIN" "$REL_MAX" "$PKG_SRC" <<'PY'
 import sys
-gm, tj, out, rmin, rmax, pkg = sys.argv[1:7]
+gm, out, hmin, hmax, pkg = sys.argv[1:6]
 sys.path.insert(0, pkg + "/tools/pcd_to_occgrid")
 import numpy as np
-from scipy.spatial import cKDTree
 from pcd_to_occgrid import load_pcd_xyz
-g = load_pcd_xyz(gm); t = load_pcd_xyz(tj)
-d, idx = cKDTree(t[:, :2]).query(g[:, :2])           # 每个 map 点 -> 最近轨迹点(本地地面代理)
-rel = g[:, 2] - t[idx, 2]
-keep = (rel >= float(rmin)) & (rel <= float(rmax)) & (d <= 40.0)   # 贴地障碍带, 丢离轨迹太远的
+g = load_pcd_xyz(gm)
+# 自适应局部地面切: 每个 0.2m xy 网格格用格内 z 低分位估当地地面,
+# 保留"地面上方 [hmin,hmax] m"的点为障碍。比旧的"相对最近轨迹点"更适配斜坡/起伏地形,
+# 且不依赖机器人是否走近该处 —— 解决斜坡场景 + 机器人没走近区域漏墙 (见 issue #61)。
+cs = 0.20
+ci = np.floor(g[:, 0] / cs).astype(np.int64)
+cj = np.floor(g[:, 1] / cs).astype(np.int64)
+key = ci * 4000037 + cj                         # xy 格哈希 (cj 跨度 << 4000037, 不碰撞)
+order = np.argsort(key, kind="stable")
+ks = key[order]; zo = g[order, 2]
+bnd = np.r_[0, np.where(np.diff(ks))[0] + 1, len(ks)]
+gh = np.empty(len(g))
+for a, b in zip(bnd[:-1], bnd[1:]):
+    seg = zo[a:b]
+    gnd = np.percentile(seg, 8) if b - a >= 8 else seg.min()   # 低分位估地面, 抗个别低飞点
+    gh[order[a:b]] = seg - gnd
+keep = (gh >= float(hmin)) & (gh <= float(hmax))
 gb = g[keep]
 with open(out, "w") as f:
     f.write("# .PCD v0.7\nVERSION 0.7\nFIELDS x y z\nSIZE 4 4 4\nTYPE F F F\nCOUNT 1 1 1\n")
     f.write("WIDTH %d\nHEIGHT 1\nVIEWPOINT 0 0 0 1 0 0 0\nPOINTS %d\nDATA ascii\n" % (len(gb), len(gb)))
     np.savetxt(f, gb, fmt="%.4f")
-print("    相对地面带保留 %d/%d 点 (%.0f%%)" % (len(gb), len(g), 100.0 * len(gb) / max(len(g), 1)))
+print("    局部地面带保留 %d/%d 点 (%.0f%%)" % (len(gb), len(g), 100.0 * len(gb) / max(len(g), 1)))
 PY
   python3 "$PKG_SRC/tools/pcd_to_occgrid/pcd_to_occgrid.py" "$GB" -o "$OUT/occgrid" \
       --resolution "$RES" --z-min -100 --z-max 100 --raycast "$OUT/trajectory.pcd" \


### PR DESCRIPTION
## 背景

客户反馈某 bag(`airy_20260612_152239`)一条走廊缺墙。深查(过程见 #61)结论:

- **点云里墙是完整的**,是 2D 出图算法漏的 —— 不是坐标系歪、不是 z 漂移、不是采集(主体)。
- 排除手段: 竖直墙反求重力偏 z 轴仅 **0.3°**(世界系正确) + 轨迹 65 处自交点 z 一致(无漂移) → 确认是**真斜坡**场景。
- 旧切法 `rel = z − 最近轨迹点 z`,带 `rel∈[-0.5,1.5] & d≤40m`。斜坡上 + 机器人没走近的地方,"最近轨迹点"既远又对不上高度,把本来有的墙切错层漏掉。

## 改动

2D 障碍提取从「相对最近轨迹点高度带」改为「**每格相对当地局部地面**」:

- 每个 `0.2m` xy 网格,用格内 z 的 **8% 低分位**估当地地面(抗个别低飞点)。
- 保留「地面上方 `[REL_MIN, REL_MAX]`」的点为障碍。
- 每格相对自己的地面 → 天然适配斜坡/起伏地形,**不依赖机器人是否走近该处**。
- 去掉旧的 `d≤40m` 轨迹距离截断(远处墙也保留)。
- raycast free 那一步不变。

**参数语义变化(默认值已改):**

| 参数 | 旧(相对最近轨迹点) | 新(相对当地地面) |
|---|---|---|
| `--rel-min` | -0.5 | **0.3**(地面上方起算,避开地面层) |
| `--rel-max` | 1.5 | **2.5** |

## 实测

`airy_20260612_152239`(真斜坡走廊): occupied **5.6 万 → 8.3 万**,斜坡走廊的墙恢复连续。

## 已知代价 / 范围

- 斜坡上的杂物、植被会多保留些噪点。**本 PR 不在切法里做清理**,交给 `map_editor` 在线擦图处理(按用户意见)。
- 机器人完全没走近的极远区域(单条走廊最末几米)点太稀疏,自适应也只能恢复一部分 —— 那是真采集不足,需补采。
- **端到端验证待补**: 改动逻辑已在该 bag 的 GlobalMap 上离线验证(墙恢复),但集成进 `map_bag.sh` 的完整 `[1/3]→[2/3]→[3/3]` 跑通,因排查期间狗(airy-dog)离线未做;合并前建议在狗上对一个真 bag 跑一遍确认。
- percentile 按格循环,几万格约增加十几秒,相对建图分钟级可接受。

refs #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)